### PR TITLE
Fix order of assembly info

### DIFF
--- a/PackageExplorer/MefServices/AssemblyFileViewer.cs
+++ b/PackageExplorer/MefServices/AssemblyFileViewer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Windows;
 using System.Windows.Controls;
@@ -29,7 +30,7 @@ namespace PackageExplorer
                 grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) });
                 grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) });
 
-                foreach (var data in assemblyData)
+                foreach (var data in assemblyData.OrderBy(d => d.Key))
                 {
                     var label = new TextBlock 
                     { 


### PR DESCRIPTION
The assembly info is unordered, and even worse, the order is not the same depending which package is opened. This makes comparing info very difficult.

E.g current version:

![image](https://cloud.githubusercontent.com/assets/5808377/12534021/0e982b2e-c247-11e5-8903-4bafee3da37b.png)
