### PR TITLE
Print exception for "plugin read failed"

### DIFF
--- a/PackageViewModel/Commands/ViewContentCommand.cs
+++ b/PackageViewModel/Commands/ViewContentCommand.cs
@@ -95,10 +95,10 @@ namespace PackageExplorerViewModel
                         }
                     }
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
                     // don't let plugin crash the app
-                    content = Resources.PluginFailToReadContent;
+                    content = Resources.PluginFailToReadContent + Environment.NewLine + ex.ToString();
                 }
 
                 if (content is string)


### PR DESCRIPTION
Can't reproduce https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/issues/22 with a local build. So printing the exception to the window in case of this error. 



![image](https://cloud.githubusercontent.com/assets/5808377/12534144/cb184b54-c24b-11e5-8023-230b0a6015aa.png)
