### PR TITLE
Add option for appending V2 API to URL

### DIFF
--- a/PackageExplorer/PublishPackageWindow.xaml
+++ b/PackageExplorer/PublishPackageWindow.xaml
@@ -1,91 +1,92 @@
 ﻿<self:StandardDialog x:Class="PackageExplorer.PublishPackageWindow" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:self="clr-namespace:PackageExplorer" MinWidth="300" MinHeight="150" FocusManager.FocusedElement="{Binding ElementName=PublishUrl}" Title="Publish Package" ShowInTaskbar="False" ResizeMode="NoResize" Width="420" FontSize="9pt" FontFamily="Segoe UI" WindowStartupLocation="CenterOwner" SizeToContent="Height">
 
-	<Window.Resources>
-		<Style TargetType="{x:Type TextBlock}" x:Key="StatusTextStyle">
-			<Style.Triggers>
-				<DataTrigger Binding="{Binding HasError}" Value="True">
-					<Setter Property="Foreground" Value="Red" />
-				</DataTrigger>
-			</Style.Triggers>
-		</Style>
+    <Window.Resources>
+        <Style TargetType="{x:Type TextBlock}" x:Key="StatusTextStyle">
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding HasError}" Value="True">
+                    <Setter Property="Foreground" Value="Red" />
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
 
-		<Style TargetType="{x:Type ComboBox}">
-			<Style.Triggers>
-				<Trigger Property="Validation.HasError" Value="True">
-					<Setter Property="ToolTip">
-						<Setter.Value>
-							<Binding Path="(Validation.Errors).CurrentItem.ErrorContent" RelativeSource="{x:Static RelativeSource.Self}" />
-						</Setter.Value>
-					</Setter>
-				</Trigger>
-			</Style.Triggers>
-		</Style>
-	</Window.Resources>
+        <Style TargetType="{x:Type ComboBox}">
+            <Style.Triggers>
+                <Trigger Property="Validation.HasError" Value="True">
+                    <Setter Property="ToolTip">
+                        <Setter.Value>
+                            <Binding Path="(Validation.Errors).CurrentItem.ErrorContent" RelativeSource="{x:Static RelativeSource.Self}" />
+                        </Setter.Value>
+                    </Setter>
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+    </Window.Resources>
 
-	<DockPanel LastChildFill="False">
-		<DockPanel.BindingGroup>
-			<BindingGroup x:Name="DialogBindingGroup" NotifyOnValidationError="true" />
-		</DockPanel.BindingGroup>
+    <DockPanel LastChildFill="False">
+        <DockPanel.BindingGroup>
+            <BindingGroup x:Name="DialogBindingGroup" NotifyOnValidationError="true" />
+        </DockPanel.BindingGroup>
 
-		<!-- Main instruction -->
-		<TextBlock DockPanel.Dock="Top" Text="Enter your publish key." FontSize="12pt" Margin="10,10,0,15" Foreground="{StaticResource TaskDialogMainInstructionBrush}" />
+        <!-- Main instruction -->
+        <TextBlock DockPanel.Dock="Top" Text="Enter your publish key." FontSize="12pt" Margin="10,10,0,15" Foreground="{StaticResource TaskDialogMainInstructionBrush}" />
 
-		<!-- Secondary instruction -->
-		<TextBlock DockPanel.Dock="Top" Margin="10,0" Text="Provide the publish Url and the publish key associated with it." TextWrapping="Wrap" />
+        <!-- Secondary instruction -->
+        <TextBlock DockPanel.Dock="Top" Margin="10,0" Text="Provide the publish Url and the publish key associated with it." TextWrapping="Wrap" />
 
-		<!-- Id & Version -->
-		<TextBlock DockPanel.Dock="Top" Margin="10,10,10,0">
-			<TextBlock.Inlines>
-				<Run Text="Id: " />
-				<Run FontWeight="Bold" Text="{Binding Id, Mode=OneTime}" />
-				<Run Text=" Version: " />
-				<Run FontWeight="Bold" Text="{Binding Version, Mode=OneTime}" />
-			</TextBlock.Inlines>
-		</TextBlock>
-		
-		<!-- Publish Url -->
-		<DockPanel DockPanel.Dock="Top" Margin="7,8,10,5">
-			<Label DockPanel.Dock="Left" Target="{Binding ElementName=PublishUrl}" Content="Publish _Url:" />
-			<ComboBox x:Name="PublishUrl" ItemsSource="{Binding PublishSources}" IsReadOnly="False" IsEditable="True" VerticalContentAlignment="Center" SelectedItem="{Binding SelectedPublishItem, BindingGroupName=Random}" IsEnabled="{Binding CanPublish}">
-				<ComboBox.Text>
-					<Binding Path="PublishUrl">
-						<Binding.ValidationRules>
-							<self:PublishUrlValidationRule />
-						</Binding.ValidationRules>
-					</Binding>
-				</ComboBox.Text>
-			</ComboBox>
-		</DockPanel>
-				
-		<!-- Publish key -->
-		<DockPanel DockPanel.Dock="Top" Margin="7,0,10,5">
-			<Label DockPanel.Dock="Left" Target="{Binding ElementName=PublishKey}" Content="Publish _key:" />
-			<TextBox x:Name="PublishKey" VerticalContentAlignment="Center" IsEnabled="{Binding CanPublish}" Margin="0" Text="{Binding PublishKey}">
-			</TextBox>
-		</DockPanel>
-		
-		<!-- Publish as unlisted flag -->
+        <!-- Id & Version -->
+        <TextBlock DockPanel.Dock="Top" Margin="10,10,10,0">
+            <TextBlock.Inlines>
+                <Run Text="Id: " />
+                <Run FontWeight="Bold" Text="{Binding Id, Mode=OneTime}" />
+                <Run Text=" Version: " />
+                <Run FontWeight="Bold" Text="{Binding Version, Mode=OneTime}" />
+            </TextBlock.Inlines>
+        </TextBlock>
+
+        <!-- Publish Url -->
+        <DockPanel DockPanel.Dock="Top" Margin="7,8,10,5">
+            <Label DockPanel.Dock="Left" Target="{Binding ElementName=PublishUrl}" Content="Publish _Url:" Width="75" />
+            <ComboBox x:Name="PublishUrl" ItemsSource="{Binding PublishSources}" IsReadOnly="False" IsEditable="True" VerticalContentAlignment="Center" SelectedItem="{Binding SelectedPublishItem, BindingGroupName=Random}" IsEnabled="{Binding CanPublish}">
+                <ComboBox.Text>
+                    <Binding Path="PublishUrl">
+                        <Binding.ValidationRules>
+                            <self:PublishUrlValidationRule />
+                        </Binding.ValidationRules>
+                    </Binding>
+                </ComboBox.Text>
+            </ComboBox>
+        </DockPanel>
+
+        <!-- Publish key -->
+        <DockPanel DockPanel.Dock="Top" Margin="7,0,10,5">
+            <Label DockPanel.Dock="Left" Target="{Binding ElementName=PublishKey}" Content="Publish _key:" Width="75" />
+            <TextBox x:Name="PublishKey" VerticalContentAlignment="Center" IsEnabled="{Binding CanPublish}" Margin="0" Text="{Binding PublishKey}">
+            </TextBox>
+        </DockPanel>
+        <CheckBox Margin="10,5,0,5" VerticalContentAlignment="Center" IsChecked="{Binding AppendV2ApiToUrl, BindingGroupName=Nothing, Mode=TwoWay}" DockPanel.Dock="Top" IsEnabled="{Binding CanPublish}" HorizontalAlignment="Left" Content="Append 'api/v2/package' to publish url" ToolTip="Check this for publishing to NuGet.org ."/>
+
+        <!-- Publish as unlisted flag -->
         <CheckBox Margin="10,5" VerticalContentAlignment="Center" IsChecked="{Binding PublishAsUnlisted, Mode=TwoWay, BindingGroupName=Nothing}" DockPanel.Dock="Top" IsEnabled="{Binding CanPublish}" HorizontalAlignment="Left" Content="U_nlist this package so that it doesn't appear in search results." ToolTip="If checked, the package will be unlisted."></CheckBox>
 
-		<!-- Progress bar -->
-		<ProgressBar Margin="10,5" IsIndeterminate="true" Visibility="{Binding ShowProgress, Converter={StaticResource boolToVis}, FallbackValue=Collapsed}" DockPanel.Dock="Top" Height="22" Maximum="100" Value="{Binding PercentComplete, Mode=OneWay}" />
+        <!-- Progress bar -->
+        <ProgressBar Margin="10,5" IsIndeterminate="true" Visibility="{Binding ShowProgress, Converter={StaticResource boolToVis}, FallbackValue=Collapsed}" DockPanel.Dock="Top" Height="22" Maximum="100" Value="{Binding PercentComplete, Mode=OneWay}" />
 
-		<!-- Status text -->
-		<TextBlock Style="{StaticResource StatusTextStyle}" Text="{Binding Status}" Margin="10,5" Visibility="{Binding Status, Converter={StaticResource NullToVisibilityConverter}, FallbackValue=Collapsed}" DockPanel.Dock="Top" TextWrapping="Wrap" />
+        <!-- Status text -->
+        <TextBlock Style="{StaticResource StatusTextStyle}" Text="{Binding Status}" Margin="10,5" Visibility="{Binding Status, Converter={StaticResource NullToVisibilityConverter}, FallbackValue=Collapsed}" DockPanel.Dock="Top" TextWrapping="Wrap" />
 
-		<Border DockPanel.Dock="Top" Margin="0,20,0,0" BorderThickness="0,0.5,0,0" BorderBrush="{DynamicResource ResourceKey={x:Static SystemColors.ActiveBorderBrushKey}}" Background="{DynamicResource ResourceKey={x:Static SystemColors.ControlBrushKey}}">
-			<UniformGrid Margin="10,5" HorizontalAlignment="Right" Rows="1" Columns="2">
-				<Button x:Name="PublishButton" IsDefault="True" Padding="15,2" Content="_Publish" Margin="5" Click="OnPublishButtonClick">
-					<Button.IsEnabled>
-						<MultiBinding Converter="{StaticResource andConverter}">
-							<Binding Path="Text" ElementName="PublishUrl" Converter="{StaticResource nullToBoolConverter}" />
-							<Binding Path="Text" ElementName="PublishKey" Converter="{StaticResource nullToBoolConverter}" />
-							<Binding Path="CanPublish" />
-						</MultiBinding>
-					</Button.IsEnabled>
-				</Button>
-				<Button IsCancel="True" Content="Close" Margin="5,5,0,5" Padding="15,2" Click="CloseButton_Click"></Button>
-			</UniformGrid>
-		</Border>
-	</DockPanel>
+        <Border DockPanel.Dock="Top" Margin="0,20,0,0" BorderThickness="0,0.5,0,0" BorderBrush="{DynamicResource ResourceKey={x:Static SystemColors.ActiveBorderBrushKey}}" Background="{DynamicResource ResourceKey={x:Static SystemColors.ControlBrushKey}}">
+            <UniformGrid Margin="10,5" HorizontalAlignment="Right" Rows="1" Columns="2">
+                <Button x:Name="PublishButton" IsDefault="True" Padding="15,2" Content="_Publish" Margin="5" Click="OnPublishButtonClick">
+                    <Button.IsEnabled>
+                        <MultiBinding Converter="{StaticResource andConverter}">
+                            <Binding Path="Text" ElementName="PublishUrl" Converter="{StaticResource nullToBoolConverter}" />
+                            <Binding Path="Text" ElementName="PublishKey" Converter="{StaticResource nullToBoolConverter}" />
+                            <Binding Path="CanPublish" />
+                        </MultiBinding>
+                    </Button.IsEnabled>
+                </Button>
+                <Button IsCancel="True" Content="Close" Margin="5,5,0,5" Padding="15,2" Click="CloseButton_Click"></Button>
+            </UniformGrid>
+        </Border>
+    </DockPanel>
 </self:StandardDialog>

--- a/PackageViewModel/PublishPackage/PublishPackageViewModel.cs
+++ b/PackageViewModel/PublishPackage/PublishPackageViewModel.cs
@@ -21,6 +21,7 @@ namespace PackageExplorerViewModel
         private bool _hasError;
         private string _publishKey;
         private bool? _publishAsUnlisted = true;
+        private bool? _appendV2ApiToUrl = true;
         private string _selectedPublishItem;
         private bool _showProgress;
         private string _status;
@@ -114,6 +115,19 @@ namespace PackageExplorerViewModel
             }
         }
 
+        public bool? AppendV2ApiToUrl
+        {
+            get { return _appendV2ApiToUrl; }
+            set
+            {
+                if (_appendV2ApiToUrl != value)
+                {
+                    _appendV2ApiToUrl = value;
+                    OnPropertyChanged("AppendV2ApiToUrl");
+                }
+            }
+        }
+        
         public string Id
         {
             get { return _package.Id; }
@@ -223,7 +237,7 @@ namespace PackageExplorerViewModel
 
             try
             {
-                await GalleryServer.PushPackage(PublishKey, _packageFilePath, _package, PublishAsUnlisted ?? false);
+                await GalleryServer.PushPackage(PublishKey, _packageFilePath, _package, PublishAsUnlisted ?? false, AppendV2ApiToUrl ?? false);
 
                 OnCompleted();
             }


### PR DESCRIPTION
Fixes #2 

![image](https://cloud.githubusercontent.com/assets/5808377/12536480/08338818-c2a7-11e5-8a6e-d81806ef3e6e.png)

@dsplaisted , @rikoe 

Please your thoughts on this change. Removing always `api/v2/package` would be a non-backwards-compatible change. (e.g. you need to change the publish URL when this is released).

The option is maybe not the best solution, but it's an improvement and makes the process more transparent. 