### PR TITLE
Disable Windows Store popup

### DIFF
--- a/PackageExplorer/App.xaml.cs
+++ b/PackageExplorer/App.xaml.cs
@@ -47,7 +47,8 @@ namespace PackageExplorer
             var window = Container.GetExportedValue<MainWindow>();
             window.Show();
 
-            CheckWindows8AndDisplayUpsellDialog();
+            //Disable this sellup as it doesn't work well with Windows 10 and the Windows Store application is not maintained.
+            //CheckWindows8AndDisplayUpsellDialog();
 
             if (e.Args.Length > 0)
             {


### PR DESCRIPTION
It doesn't work well with Windows 10 and the Windows Store application
is not maintained.

![image](https://cloud.githubusercontent.com/assets/5808377/12536519/0e822a66-c2a8-11e5-8e1d-b27fe2f5a417.png)


fixes #33