### PR TITLE
Support of server authentication

### DIFF
--- a/PackageExplorer/MefServices/PackageDownloader.cs
+++ b/PackageExplorer/MefServices/PackageDownloader.cs
@@ -133,7 +133,8 @@ namespace PackageExplorer
 
         private async Task<string> DownloadData(Uri url, Action<int, string> reportProgressAction, CancellationToken cancelToken)
         {
-            var httpClient = new HttpClient();
+            var handler = new HttpClientHandler { Credentials = System.Net.CredentialCache.DefaultCredentials };
+            var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(HttpUtility.CreateUserAgentString(Constants.UserAgentClient));
 
             using (HttpResponseMessage response = await httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancelToken))


### PR DESCRIPTION
From
https://npe.codeplex.com/SourceControl/network/forks/jkalmbach/ProxySupport/contribution/8329

> Currently the Package Explorer uses no authetication to communicate with the nuget server. This works in most cases. If you work in a company which uses an own nuget-server which requres autehtication, then the Package Explorer dies not work, because it always returns "401 Unauthorized". One solution is not to just use the default credentials to allow authetntication with the current user.
This change has no side effects for anonymous access, this works as before. Now also the servers which require autehtication will work.