### PR TITLE
Add support for exclude attribute on dependency

### DIFF
--- a/Core/Authoring/Manifest.cs
+++ b/Core/Authoring/Manifest.cs
@@ -206,7 +206,8 @@ namespace NuGet
                     select new ManifestDependency
                     {
                         Id = dependency.Id.SafeTrim(),
-                        Version = dependency.VersionSpec.ToStringSafe()
+                        Version = dependency.VersionSpec.ToStringSafe(),
+                        Exclude = dependency.Exclude.SafeTrim()
                     }).ToList();
         }
 

--- a/Core/Authoring/ManifestDependency.cs
+++ b/Core/Authoring/ManifestDependency.cs
@@ -14,5 +14,8 @@ namespace NuGet
 
         [XmlAttribute("version")]
         public string Version { get; set; }
+
+        [XmlAttribute("exclude")]
+        public string Exclude { get; set; }
     }
 }

--- a/Core/Authoring/ManifestMetadata.cs
+++ b/Core/Authoring/ManifestMetadata.cs
@@ -396,7 +396,8 @@ namespace NuGet
             var dependencies = from d in manifestDependencySet.Dependencies
                                select new PackageDependency(
                                    d.Id,
-                                   String.IsNullOrEmpty(d.Version) ? null : VersionUtility.ParseVersionSpec(d.Version));
+                                   String.IsNullOrEmpty(d.Version) ? null : VersionUtility.ParseVersionSpec(d.Version),
+                                   d.Exclude);
 
             return new PackageDependencySet(targetFramework, dependencies);
         }

--- a/Core/Authoring/ManifestReader.cs
+++ b/Core/Authoring/ManifestReader.cs
@@ -218,7 +218,8 @@ namespace NuGet
                     select new ManifestDependency
                     {
                         Id = element.GetOptionalAttributeValue("id").SafeTrim(),
-                        Version = element.GetOptionalAttributeValue("version").SafeTrim()
+                        Version = element.GetOptionalAttributeValue("version").SafeTrim(),
+                        Exclude = element.GetOptionalAttributeValue("exclude").SafeTrim()
                     }).ToList();
         }
 

--- a/Core/Authoring/nuspec.xsd
+++ b/Core/Authoring/nuspec.xsd
@@ -9,6 +9,7 @@
     <xs:complexType name="dependency">
         <xs:attribute name="id" type="xs:string" use="required" />
         <xs:attribute name="version" type="xs:string" use="optional" />
+        <xs:attribute name="exclude" type="xs:string" use="optional" />
     </xs:complexType>
 
     <xs:complexType name="dependencyGroup">

--- a/PackageExplorer/PackageDependencyEditor.xaml
+++ b/PackageExplorer/PackageDependencyEditor.xaml
@@ -125,6 +125,14 @@
                             </GridViewColumn.CellTemplate>
                         </GridViewColumn>
 
+                        <GridViewColumn Header="Exclude" Width="45">
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Exclude, TargetNullValue='(not set)', Mode=OneWay}" TextAlignment="Center" />
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
+                        
                         <GridViewColumn Width="80">
                             <GridViewColumn.CellTemplate>
                                 <DataTemplate>

--- a/PackageViewModel/EditablePackageDependency.cs
+++ b/PackageViewModel/EditablePackageDependency.cs
@@ -9,6 +9,7 @@ namespace PackageExplorerViewModel
     public class EditablePackageDependency : INotifyPropertyChanged, IDataErrorInfo
     {
         private string _id;
+        private string _exclude;
         private IVersionSpec _versionSpec;
         private Func<EditablePackageDependencySet> _getActiveDependencySet;
 
@@ -40,6 +41,19 @@ namespace PackageExplorerViewModel
                 {
                     _versionSpec = value;
                     RaisePropertyChange("VersionSpec");
+                }
+            }
+        }
+
+        public string Exclude
+        {
+            get { return _exclude; }
+            set
+            {
+                if (_exclude != value)
+                {
+                    _exclude = value;
+                    RaisePropertyChange("Exclude");
                 }
             }
         }
@@ -101,7 +115,7 @@ namespace PackageExplorerViewModel
 
         public PackageDependency AsReadOnly()
         {
-            return new PackageDependency(Id, VersionSpec);
+            return new PackageDependency(Id, VersionSpec, Exclude);
         }
     }
 }

--- a/Types/Packages/PackageDependency.cs
+++ b/Types/Packages/PackageDependency.cs
@@ -10,11 +10,11 @@ namespace NuGet
         private const string GreaterThanOrEqualTo = "\u2265";
 
         public PackageDependency(string id)
-            : this(id, null)
+            : this(id, null, null)
         {
         }
 
-        public PackageDependency(string id, IVersionSpec versionSpec)
+        public PackageDependency(string id, IVersionSpec versionSpec, string exclude)
         {
             if (String.IsNullOrEmpty(id))
             {
@@ -22,31 +22,39 @@ namespace NuGet
             }
             Id = id;
             VersionSpec = versionSpec;
+            Exclude = exclude;
         }
 
         public string Id { get; private set; }
 
         public IVersionSpec VersionSpec { get; private set; }
+        public string Exclude { get; private set; }
 
         public override string ToString()
         {
+            string excludeStr = null;
+            if (!string.IsNullOrWhiteSpace(Exclude))
+            {
+                excludeStr = " exclude=" + Exclude;
+            }
+
             if (VersionSpec == null)
             {
-                return Id;
+                return Id + excludeStr;
             }
 
             if (VersionSpec.MinVersion != null && VersionSpec.IsMinInclusive && VersionSpec.MaxVersion == null &&
                 !VersionSpec.IsMaxInclusive)
             {
                 return String.Format(CultureInfo.InvariantCulture, "{0} ({1} {2})", Id, GreaterThanOrEqualTo,
-                                     VersionSpec.MinVersion);
+                                     VersionSpec.MinVersion) + excludeStr;
             }
 
             if (VersionSpec.MinVersion != null && VersionSpec.MaxVersion != null &&
                 VersionSpec.MinVersion == VersionSpec.MaxVersion && VersionSpec.IsMinInclusive &&
                 VersionSpec.IsMaxInclusive)
             {
-                return String.Format(CultureInfo.InvariantCulture, "{0} (= {1})", Id, VersionSpec.MinVersion);
+                return String.Format(CultureInfo.InvariantCulture, "{0} (= {1})", Id, VersionSpec.MinVersion) + excludeStr;
             }
 
             var versionBuilder = new StringBuilder();
@@ -90,7 +98,9 @@ namespace NuGet
                 versionBuilder.Append(")");
             }
 
-            return Id + " " + versionBuilder;
+           
+
+            return Id + " " + versionBuilder + excludeStr;
         }
     }
 }


### PR DESCRIPTION
The latest .NET Core packages seem to have added a new attribute on the dependency. This PR adds support and fixes the crash without it.

Here's the example package:

Feed: https://dotnet.myget.org/F/dotnet-core
Package: System.Reflection.TypeExtensions rc3-23922

Try loading that without this and NPE crashes. With this, support is added throughout the UI for it. 