### PR TITLE
Show "strong name" in assembly properties

### DIFF
--- a/CodeExecutor/AppDomainWorker.cs
+++ b/CodeExecutor/AppDomainWorker.cs
@@ -36,9 +36,9 @@ namespace CodeExecutor
             return null;
         }
 
-        public Dictionary<string, string> GetAssemblyMetadata(string assemblyPath)
+        public AssemblyMetaData GetAssemblyMetadata(string assemblyPath)
         {
-            var data = new Dictionary<string, string>();
+            var data = new AssemblyMetaData();
 
             var assemblyName = AssemblyName.GetAssemblyName(assemblyPath);
             if (assemblyName == null)
@@ -49,14 +49,15 @@ namespace CodeExecutor
             // For WinRT component, we can only read Full Name. 
             if (assemblyName.ContentType == AssemblyContentType.WindowsRuntime)
             {
-                data.Add("Full Name", assemblyName.FullName);
+                data.SetFullName(assemblyName.FullName);
                 return data;
             }
 
             var assembly = Assembly.Load(assemblyName);
             if (assembly != null)
             {
-                data.Add("Full Name", assembly.FullName);
+
+                data.SetFullName(assembly.FullName);
 
                 try
                 {

--- a/CodeExecutor/AssemblyMetaData.cs
+++ b/CodeExecutor/AssemblyMetaData.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CodeExecutor
+{
+    /// <summary>
+    /// Meta data of the assembly, 
+    /// </summary>
+    [Serializable]
+    public class AssemblyMetaData : Dictionary<string, string>
+    {
+        public AssemblyMetaData()
+        {
+        }
+
+        public AssemblyMetaData(IDictionary<string, string> dictionary)
+            : base(dictionary)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:System.Collections.Generic.Dictionary`2"/> class with serialized data.
+        /// </summary>
+        /// <param name="info">A <see cref="T:System.Runtime.Serialization.SerializationInfo"/> object containing the information required to serialize the <see cref="T:System.Collections.Generic.Dictionary`2"/>.</param><param name="context">A <see cref="T:System.Runtime.Serialization.StreamingContext"/> structure containing the source and destination of the serialized stream associated with the <see cref="T:System.Collections.Generic.Dictionary`2"/>.</param>
+        protected AssemblyMetaData(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+
+        /// <summary>
+        /// Set Fullname of the assembly and determine strong name.
+        /// </summary>
+        /// <remarks>Helper</remarks>
+        public void SetFullName(string value)
+        {
+            this[FullNameLabel] = value;
+
+            try
+            {
+                var assemblyName = new AssemblyName(value);
+                var publicKey = assemblyName.GetPublicKeyToken();
+                var isStrongNamed = publicKey != null && publicKey.Length > 0;
+
+                if (isStrongNamed)
+                {
+                    this[StrongNamedLabel] = string.Format("Yes, version {0}", assemblyName.Version.ToString());
+                }
+                else
+                {
+                    this[StrongNamedLabel] = "No";
+                }
+            }
+            catch (Exception)
+            {
+                //ignore
+            }
+        }
+
+        private const string FullNameLabel = "Full Name";
+        private const string StrongNamedLabel = "Strong Name";
+    }
+}

--- a/CodeExecutor/CodeExecutor.csproj
+++ b/CodeExecutor/CodeExecutor.csproj
@@ -44,6 +44,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppDomainWorker.cs" />
+    <Compile Include="AssemblyMetaData.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RemoteCodeExecutor.cs" />
   </ItemGroup>

--- a/CodeExecutor/RemoteCodeExecutor.cs
+++ b/CodeExecutor/RemoteCodeExecutor.cs
@@ -26,14 +26,14 @@ namespace CodeExecutor
             }
         }
 
-        public static Dictionary<string, string> GetAssemblyMetadata(string assemblyPath)
+        public static AssemblyMetaData GetAssemblyMetadata(string assemblyPath)
         {
             if (!File.Exists(assemblyPath))
             {
                 return null;
             }
 
-            Dictionary<string, string> result = null;
+            AssemblyMetaData result = null;
             ExecuteRemotely(worker => result = worker.GetAssemblyMetadata(assemblyPath));
             return result;
         }


### PR DESCRIPTION
Show "strong name" in assembly properties + refactor AssemblyMetaData

If a strong name is good or not, is a discussion. But making it clear is a big win.

Example:
![image](https://cloud.githubusercontent.com/assets/5808377/14501765/54eab83a-01a8-11e6-8c22-4bb2d36cd608.png)
