### PR TITLE
Better handling of large packages

### DIFF
--- a/Core/Packages/ZipPackage.cs
+++ b/Core/Packages/ZipPackage.cs
@@ -183,14 +183,11 @@ namespace NuGet
 
         public IEnumerable<IPackageFile> GetFiles()
         {
-            using (Stream stream = _streamFactory())
-            {
-                Package package = Package.Open(stream);
+            Package package = Package.Open(_streamFactory()); // should not close
 
-                return (from part in package.GetParts()
-                        where IsPackageFile(part)
-                        select new ZipPackageFile(part)).ToList();
-            }
+            return (from part in package.GetParts()
+                    where IsPackageFile(part)
+                    select new ZipPackageFile(part)).ToList();
         }
 
         public Stream GetStream()

--- a/Core/Packages/ZipPackageFile.cs
+++ b/Core/Packages/ZipPackageFile.cs
@@ -8,19 +8,13 @@ namespace NuGet
 {
     internal class ZipPackageFile : PackageFileBase
     {
-        private readonly Func<MemoryStream> _streamFactory;
+        private readonly Func<Stream> _streamFactory;
 
         public ZipPackageFile(PackagePart part) 
             : base(UriUtility.GetPath(part.Uri))
         {
             Debug.Assert(part != null, "part should not be null");
-
-            byte[] buffer;
-            using (Stream partStream = part.GetStream())
-            {
-                buffer = partStream.ReadAllBytes();
-            }
-            _streamFactory = () => new MemoryStream(buffer);
+            _streamFactory = () => part.GetStream();
         }
 
         public override Stream GetStream()


### PR DESCRIPTION
Resolved OutOfMemory exceptions for multiple opening of packages >256Mb unpacked (tested on Wt)
Also, looks like it improves responsiveness while opening big packages.