### PR TITLE
Remove wrong sort by version which compared strings

### DIFF
--- a/PackageViewModel/PackageChooser/PackageInfoViewModel.cs
+++ b/PackageViewModel/PackageChooser/PackageInfoViewModel.cs
@@ -294,9 +294,6 @@ namespace PackageExplorerViewModel
                 results = await Task.Run((Func<PackageInfo[]>)query.ToArray, token);
             }
 
-            // sort by Version descending
-            Array.Sort(results, (a, b) => b.Version.CompareTo(a.Version));
-
             return results;
         }
 


### PR DESCRIPTION
this is also not needed because the packages were already [sorted by published date](https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/blob/master/PackageViewModel/PackageChooser/PackageInfoViewModel.cs#L178)

Before:
![image](https://cloud.githubusercontent.com/assets/4009570/14782348/192b3b7c-0ae9-11e6-81a1-ca1999d839db.png)

After:
![image](https://cloud.githubusercontent.com/assets/4009570/14782336/089e2d1e-0ae9-11e6-9e14-60364bd6c967.png)
