### PR TITLE
Catch correct exception thrown from Delete()

### DIFF
--- a/Core/Repositories/MachineCache.cs
+++ b/Core/Repositories/MachineCache.cs
@@ -104,7 +104,10 @@ namespace NuGet
                             packageFile.Delete();
                         }
                     }
-                    catch (FileNotFoundException)
+                    catch (IOException)
+                    {
+                    }
+                    catch (SecurityException)
                     {
                     }
                     catch (UnauthorizedAccessException)


### PR DESCRIPTION
Fixes https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/issues/127.

[The documentation for `FileInfo.Delete()`](https://msdn.microsoft.com/en-us/library/system.io.fileinfo.delete(v=vs.110).aspx) says that it can throw `IOException`, `SecurityException` and `UnauthorizedAccessException`, so I have removed `FileNotFoundException`, which cannot be thrown by it, added `IOException` to fix the bug and also added `SecurityException` just in case. [`FileInfo.Exists()`](https://msdn.microsoft.com/en-us/library/system.io.fileinfo.exists(v=vs.110).aspx) does not throw.