### PR TITLE
修复Xamarin.iOS被修改为Xamarin iOS的bug

### DIFF
--- a/Core/Utility/VersionUtility.cs
+++ b/Core/Utility/VersionUtility.cs
@@ -57,7 +57,7 @@ namespace NuGet
                 { "Mono", "Mono" },
                 { "native", "native" },
                 { "dnxcore", "DNXCore" },
-                { "Xamarin.ios", "Xamarin iOS" },
+                { "Xamarin.ios", "Xamarin.iOS" },
                 { "Xamarin.mac", "Xamarin Mac" },
                 { "uap", "Windows 10 Universal App Platform" },
             };


### PR DESCRIPTION
使框架名保持一致