### PR TITLE
Support listing and downloading packages when credentials are provided in URL

### DIFF
--- a/Core/Repositories/DataServicePackageRepository.cs
+++ b/Core/Repositories/DataServicePackageRepository.cs
@@ -11,16 +11,16 @@ namespace NuGetPe
         private readonly DataServiceContext _context;
         private DataServiceQuery<DataServicePackage> _query;
 
-        public DataServicePackageRepository(Uri uri)
-        {
-            _context = new DataServiceContext(uri);
-            _context.Credentials = CredentialCache.DefaultCredentials;
-            _context.SendingRequest += OnSendingRequest;
-            _context.IgnoreMissingProperties = true;
-            _context.Credentials = CredentialCache.DefaultCredentials;
-        }
+	    public DataServicePackageRepository(Uri uri, ICredentials credentials)
+	    {
+		    _context = new DataServiceContext(uri);
+		    _context.Credentials = credentials;
+		    _context.SendingRequest += OnSendingRequest;
+		    _context.IgnoreMissingProperties = true;
+		    _context.Credentials = credentials;
+	    }
 
-        public string Source
+	    public string Source
         {
             get { return _context.BaseUri.OriginalString; }
         }

--- a/PackageExplorer/MefServices/CredentialManager.cs
+++ b/PackageExplorer/MefServices/CredentialManager.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Net;
+using PackageExplorerViewModel.Types;
+
+namespace PackageExplorer.MefServices
+{
+	[Export(typeof(ICredentialManager))]
+	internal sealed class CredentialManager : ICredentialManager
+	{
+		private readonly object _feedsLock = new object();
+		private readonly List<Tuple<Uri, ICredentials>> _feeds;
+
+		public CredentialManager()
+		{
+			_feeds = new List<Tuple<Uri, ICredentials>>();
+		}
+
+		public void TryAddUriCredentials(Uri feedUri)
+		{
+			// Support username and password in feed URL as specified in RFC 1738
+			if (!string.IsNullOrEmpty(feedUri.UserInfo))
+			{
+				var userInfoSplitted = feedUri.UserInfo.Split(new[] {':'}, StringSplitOptions.RemoveEmptyEntries);
+				if (userInfoSplitted.Length >= 2)
+				{
+					Add(new NetworkCredential(userInfoSplitted[0], userInfoSplitted[1]), feedUri);
+				}
+			}
+		}
+
+		public void Add(ICredentials credentials, Uri feedUri)
+		{
+			lock (_feedsLock)
+			{
+				_feeds.RemoveAll(x => x.Item1 == feedUri);
+				_feeds.Add(new Tuple<Uri, ICredentials>(feedUri, credentials));
+			}
+		}
+
+		public ICredentials Get(Uri uri)
+		{
+			var credentials = CredentialCache.DefaultCredentials;
+			lock (_feedsLock)
+			{
+				var matchingFeeds = _feeds.Where(x => string.Compare(uri.Scheme, x.Item1.Scheme, StringComparison.OrdinalIgnoreCase) == 0 && 
+													  string.Compare(uri.Host, x.Item1.Host, StringComparison.OrdinalIgnoreCase) == 0 &&
+													  uri.AbsolutePath.Contains(x.Item1.AbsolutePath));
+				if (matchingFeeds.Any())
+				{
+					credentials = matchingFeeds.First().Item2;
+				}
+			}
+			return credentials;
+		}
+	}
+}

--- a/PackageExplorer/MefServices/PackageDownloader.cs
+++ b/PackageExplorer/MefServices/PackageDownloader.cs
@@ -10,12 +10,13 @@ using NuGetPe;
 using NuGetPackageExplorer.Types;
 using Ookii.Dialogs.Wpf;
 using Constants = PackageExplorerViewModel.Constants;
+using PackageExplorerViewModel.Types;
 
 namespace PackageExplorer
 {
-    using HttpClient = System.Net.Http.HttpClient;
+	using HttpClient = System.Net.Http.HttpClient;
 
-    [Export(typeof(IPackageDownloader))]
+	[Export(typeof(IPackageDownloader))]
     internal class PackageDownloader : IPackageDownloader
     {
         private ProgressDialog _progressDialog;
@@ -27,9 +28,12 @@ namespace PackageExplorer
         [Import]
         public IUIServices UIServices { get; set; }
 
-        #region IPackageDownloader Members
+		[Import(typeof(ICredentialManager))]
+		public ICredentialManager CredentialManager { get; set; }
+		
+		#region IPackageDownloader Members
 
-        public async Task Download(string targetFilePath, Uri downloadUri, string packageId, string packageVersion)
+		public async Task Download(string targetFilePath, Uri downloadUri, string packageId, string packageVersion)
         {
             string sourceFilePath = await DownloadWithProgress(downloadUri, packageId, packageVersion);
             if (!String.IsNullOrEmpty(sourceFilePath))
@@ -133,7 +137,8 @@ namespace PackageExplorer
 
         private async Task<string> DownloadData(Uri url, Action<int, string> reportProgressAction, CancellationToken cancelToken)
         {
-            var handler = new HttpClientHandler { UseDefaultCredentials = true };
+	        var handler = new HttpClientHandler();
+	        handler.Credentials = CredentialManager.Get(url);
             var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(HttpUtility.CreateUserAgentString(Constants.UserAgentClient));
 

--- a/PackageExplorer/PackageExplorer.csproj
+++ b/PackageExplorer/PackageExplorer.csproj
@@ -264,6 +264,7 @@
     <Compile Include="Converters\NormalizeTextConverter.cs" />
     <Compile Include="Converters\StringShortenerConverter.cs" />
     <Compile Include="Converters\TargetFrameworkConverter.cs" />
+    <Compile Include="MefServices\CredentialManager.cs" />
     <Compile Include="MefServices\RtfFileViewer.cs" />
     <Compile Include="PackageDownloadRequestedEventArgs.cs" />
     <Compile Include="PackageReferencesEditor.xaml.cs">

--- a/PackageViewModel/PackageChooser/PackageChooserViewModel.cs
+++ b/PackageViewModel/PackageChooser/PackageChooserViewModel.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using NuGetPe;
+using PackageExplorerViewModel.Types;
 
 namespace PackageExplorerViewModel
 {
@@ -27,6 +28,7 @@ namespace PackageExplorerViewModel
         private bool _isEditable = true;
         private IPackageRepository _packageRepository;
         private MruPackageSourceManager _packageSourceManager;
+	    private readonly ICredentialManager _credentialManager;
         private bool _showPrereleasePackages;
         private bool _autoLoadPackages;
         private string _sortColumn;
@@ -37,6 +39,7 @@ namespace PackageExplorerViewModel
 
         public PackageChooserViewModel(
             MruPackageSourceManager packageSourceManager,
+			ICredentialManager credentialManager,
             bool showPrereleasePackages,
             bool autoLoadPackages,
             string fixedPackageSource)
@@ -45,6 +48,10 @@ namespace PackageExplorerViewModel
             {
                 throw new ArgumentNullException("packageSourceManager");
             }
+	        if (credentialManager == null)
+	        {
+		        throw new ArgumentNullException("credentialManager");
+	        }
 
             _showPrereleasePackages = showPrereleasePackages;
             _fixedPackageSource = fixedPackageSource;
@@ -58,6 +65,7 @@ namespace PackageExplorerViewModel
             ChangePackageSourceCommand = new RelayCommand<string>(ChangePackageSource);
             CancelCommand = new RelayCommand(CancelCommandExecute, CanCancelCommandExecute);
             _packageSourceManager = packageSourceManager;
+	        _credentialManager = credentialManager;
         }
 
         public IPackageRepository ActiveRepository
@@ -299,7 +307,7 @@ namespace PackageExplorerViewModel
         {
             if (_packageRepository == null)
             {
-                _packageRepository = PackageRepositoryFactory.CreateRepository(PackageSource);
+				_packageRepository = PackageRepositoryFactory.CreateRepository(PackageSource, _credentialManager);
             }
 
             return _packageRepository;

--- a/PackageViewModel/PackageChooser/PackageRepositoryFactory.cs
+++ b/PackageViewModel/PackageChooser/PackageRepositoryFactory.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using NuGetPe;
+using PackageExplorerViewModel.Types;
 
 namespace PackageExplorerViewModel
 {
     internal static class PackageRepositoryFactory
     {
-        public static IPackageRepository CreateRepository(string source)
+        public static IPackageRepository CreateRepository(string source, ICredentialManager credentialManager)
         {
             if (source == null)
             {
@@ -20,7 +21,8 @@ namespace PackageExplorerViewModel
             }
             else
             {
-                return new DataServicePackageRepository(uri);
+				credentialManager.TryAddUriCredentials(uri);
+                return new DataServicePackageRepository(uri, credentialManager.Get(uri));
             }
         }
     }

--- a/PackageViewModel/PackageViewModel.csproj
+++ b/PackageViewModel/PackageViewModel.csproj
@@ -77,6 +77,7 @@
     <Compile Include="PackagePart\IEditablePackageFile.cs" />
     <Compile Include="PackagePart\PackageMetadataFile.cs" />
     <Compile Include="PackageChooser\PackageInfoViewModel.cs" />
+    <Compile Include="Types\ICredentialManager.cs" />
     <Compile Include="Utilities\FileHelper.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="PackageAnalyzer\MisplacedTransformFileRule.cs" />

--- a/PackageViewModel/PackageViewModelFactory.cs
+++ b/PackageViewModel/PackageViewModelFactory.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
 using NuGetPe;
 using NuGetPackageExplorer.Types;
+using PackageExplorerViewModel.Types;
 
 namespace PackageExplorerViewModel
 {
@@ -40,7 +41,10 @@ namespace PackageExplorerViewModel
         [Import(typeof(IPackageDownloader))]
         public IPackageDownloader PackageDownloader { get; set; }
 
-        [SuppressMessage("Microsoft.Design", "CA1002:DoNotExposeGenericLists"),
+		[Import(typeof(ICredentialManager))]
+		public ICredentialManager CredentialManager { get; set; }
+
+		[SuppressMessage("Microsoft.Design", "CA1002:DoNotExposeGenericLists"),
          SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly"),
          SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
         [ImportMany(AllowRecomposition = true)]
@@ -71,6 +75,7 @@ namespace PackageExplorerViewModel
         {
             var model = new PackageChooserViewModel(
                 new MruPackageSourceManager(new PackageSourceSettings(SettingsManager)),
+				CredentialManager,
                 SettingsManager.ShowPrereleasePackages,
                 SettingsManager.AutoLoadPackages,
                 fixedPackageSource);

--- a/PackageViewModel/Types/ICredentialManager.cs
+++ b/PackageViewModel/Types/ICredentialManager.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Net;
+
+namespace PackageExplorerViewModel.Types
+{
+	public interface ICredentialManager
+	{
+		void TryAddUriCredentials(Uri feedUri);
+
+		void Add(ICredentials credentials, Uri feedUri);
+
+		ICredentials Get(Uri uri);
+	}
+}


### PR DESCRIPTION
supersedes https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/pull/140

> Here's a basic implementation of supporting private feeds.
Credentials can be provided within the URL (http://user:pwd@feedUrl). 
Not very secure and no UI support but did the job for me.

same changes, including conflict fix

