### PR TITLE
Fix for #145 Holds on file handle

### DIFF
--- a/Core/Packages/ZipPackage.cs
+++ b/Core/Packages/ZipPackage.cs
@@ -197,11 +197,14 @@ namespace NuGetPe
 
         public IEnumerable<IPackageFile> GetFiles()
         {
-            Package package = Package.Open(_streamFactory()); // should not close
+            using (Stream stream = _streamFactory())
+            {
+                Package package = Package.Open(stream); // should not close
 
-            return (from part in package.GetParts()
-                    where IsPackageFile(part)
-                    select new ZipPackageFile(part)).ToList();
+                return (from part in package.GetParts()
+                        where IsPackageFile(part)
+                        select new ZipPackageFile(part)).ToList();
+            }
         }
 
         public Stream GetStream()


### PR DESCRIPTION
I created a small fix for issue #145, the GetFiles method on ZipPackage did not close the stream. I saw too late that there already was another fix. Now you can choose which one to merge ;-)