### PR TITLE
Using the OpenSaveFileDialog will now default to the directory of the…

### DIFF
--- a/PackageExplorer/MefServices/UIServices.cs
+++ b/PackageExplorer/MefServices/UIServices.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel.Composition;
 using System.Globalization;
+using System.IO;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Threading;
@@ -28,7 +29,7 @@ namespace PackageExplorer
                              Filter = filter,
                              FileName = defaultFileName,
                              ValidateNames = true,
-                             InitialDirectory = initialDirectory
+                             InitialDirectory = !string.IsNullOrEmpty(initialDirectory) ? Path.GetDirectoryName(initialDirectory) : initialDirectory
                          };
 
             bool? result = dialog.ShowDialog();


### PR DESCRIPTION
This should solve issue #164.

It's caused because the filename is included when setting the InitialDirectory property which as of Vista causes it to use a different path. [FileDialog.InitialDirectory - MSDN](https://msdn.microsoft.com/en-us/library/system.windows.forms.filedialog.initialdirectory(v=vs.110).aspx)