### PR TITLE
Shows Assemly information when opening package via double click

### DIFF
--- a/CodeExecutor/RemoteCodeExecutor.cs
+++ b/CodeExecutor/RemoteCodeExecutor.cs
@@ -51,9 +51,6 @@ namespace CodeExecutor
 
                 workerAction(worker);
             }
-            catch (Exception)
-            {
-            }
             finally
             {
                 AppDomain.Unload(domain);

--- a/CodeExecutor/RemoteCodeExecutor.cs
+++ b/CodeExecutor/RemoteCodeExecutor.cs
@@ -47,7 +47,7 @@ namespace CodeExecutor
                 domain.Load(typeof(RemoteCodeExecutor).Assembly.GetName());
 
                 var worker = (AppDomainWorker)domain.CreateInstanceFromAndUnwrap(
-                    "CodeExecutor.dll", "CodeExecutor.AppDomainWorker");
+                    Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "CodeExecutor.dll"), "CodeExecutor.AppDomainWorker");
 
                 workerAction(worker);
             }


### PR DESCRIPTION
This should fix issue #22. Should the empty try catch also be removed as that was hiding the error?