### PR TITLE
Issue 44 - Update portable chooser

### DIFF
--- a/PackageExplorer/PortableLibraryDialog.xaml
+++ b/PackageExplorer/PortableLibraryDialog.xaml
@@ -62,12 +62,13 @@
                     <ComboBoxItem Tag="sl5">Silverlight 5</ComboBoxItem>
                 </ComboBox>
 
-                <!-- Windows Phone -->
-                <CheckBox x:Name="WPCheckBox" Grid.Row="2" VerticalAlignment="Center" Checked="EvaluateButtonEnabledState" Unchecked="EvaluateButtonEnabledState" />
-                <ComboBox x:Name="WPFx" Grid.Row="2" IsEnabled="{Binding IsChecked, ElementName=WPCheckBox, Mode=OneWay}">
-                    <ComboBoxItem Tag="wp7">Windows Phone 7 and higher</ComboBoxItem>
-                    <ComboBoxItem Tag="wp71">Windows Phone 7.5 and higher</ComboBoxItem>
-                    <ComboBoxItem Tag="wp8">Windows Phone 8</ComboBoxItem>
+                <!-- Windows Phone Silverlight -->
+                <CheckBox x:Name="WPSLCheckBox" Grid.Row="2" VerticalAlignment="Center" Checked="EvaluateButtonEnabledState" Unchecked="EvaluateButtonEnabledState" />
+                <ComboBox x:Name="WPSLFx" Grid.Row="2" IsEnabled="{Binding IsChecked, ElementName=WPSLCheckBox, Mode=OneWay}">
+                    <ComboBoxItem Tag="wp7">Windows Phone Silverlight 7 and higher</ComboBoxItem>
+                    <ComboBoxItem Tag="wp71">Windows Phone Silverlight 7.5 and higher</ComboBoxItem>
+                    <ComboBoxItem Tag="wp8">Windows Phone Silverlight 8 and higher</ComboBoxItem>
+                    <ComboBoxItem Tag="wp81">Windows Phone Silverlight 8.1 and higher</ComboBoxItem>
                 </ComboBox>
 
                 <!-- .NET for Windows Store apps -->

--- a/PackageExplorer/PortableLibraryDialog.xaml
+++ b/PackageExplorer/PortableLibraryDialog.xaml
@@ -53,6 +53,7 @@
                     <ComboBoxItem Tag="net4">.NET Framework 4 and higher</ComboBoxItem>
                     <ComboBoxItem Tag="net403">.NET Framework 4.0.3 and higher</ComboBoxItem>
                     <ComboBoxItem Tag="net45">.NET Framework 4.5 and higher</ComboBoxItem>
+                    <ComboBoxItem Tag="net451">.NET Framework 4.5.1 and higher</ComboBoxItem>
                 </ComboBox>
 
                 <!-- Silverlight -->

--- a/PackageExplorer/PortableLibraryDialog.xaml
+++ b/PackageExplorer/PortableLibraryDialog.xaml
@@ -72,9 +72,12 @@
                     <ComboBoxItem Tag="wp81">Windows Phone Silverlight 8.1 and higher</ComboBoxItem>
                 </ComboBox>
 
-                <!-- .NET for Windows Store apps -->
-                <CheckBox x:Name="WindowsCheckBox" Grid.Row="3" Grid.ColumnSpan="2"  VerticalAlignment="Center" Content=".NET for Windows Store apps" Margin="0,2,0,0" Checked="EvaluateButtonEnabledState" Unchecked="EvaluateButtonEnabledState">
-                </CheckBox>
+                <!-- Windows -->
+                <CheckBox x:Name="WindowsCheckBox" Grid.Row="3" VerticalAlignment="Center" Checked="EvaluateButtonEnabledState" Unchecked="EvaluateButtonEnabledState" />
+                <ComboBox x:Name="WindowsFx" Grid.Row="3" IsEnabled="{Binding IsChecked, ElementName=WindowsCheckBox, Mode=OneWay}">
+                    <ComboBoxItem Tag="win8">Windows 8</ComboBoxItem>
+                    <ComboBoxItem Tag="win81">Windows 8.1</ComboBoxItem>
+                </ComboBox>
             </Grid>
         </Border>
     </DockPanel>

--- a/PackageExplorer/PortableLibraryDialog.xaml
+++ b/PackageExplorer/PortableLibraryDialog.xaml
@@ -40,6 +40,7 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
 
                 <Grid.ColumnDefinitions>
@@ -78,6 +79,9 @@
                     <ComboBoxItem Tag="win8">Windows 8</ComboBoxItem>
                     <ComboBoxItem Tag="win81">Windows 8.1</ComboBoxItem>
                 </ComboBox>
+
+                <!-- Windows Phone  -->
+                <CheckBox x:Name="WindowsPhoneCheckBox" Grid.Row="4" Grid.ColumnSpan="2"  VerticalAlignment="Center" Content="Windows Phone 8.1" Margin="0,2,0,0" Checked="EvaluateButtonEnabledState" Unchecked="EvaluateButtonEnabledState" />
             </Grid>
         </Border>
     </DockPanel>

--- a/PackageExplorer/PortableLibraryDialog.xaml
+++ b/PackageExplorer/PortableLibraryDialog.xaml
@@ -57,11 +57,11 @@
                     <ComboBoxItem Tag="net451">.NET Framework 4.5.1 and higher</ComboBoxItem>
                 </ComboBox>
 
-                <!-- Silverlight -->
-                <CheckBox x:Name="SilverlightCheckBox" Grid.Row="1" VerticalAlignment="Center" Checked="EvaluateButtonEnabledState" Unchecked="EvaluateButtonEnabledState" />
-                <ComboBox x:Name="SilverlightFx" Grid.Row="1" IsEnabled="{Binding IsChecked, ElementName=SilverlightCheckBox, Mode=OneWay}">
-                    <ComboBoxItem Tag="sl4">Silverlight 4 and higher</ComboBoxItem>
-                    <ComboBoxItem Tag="sl5">Silverlight 5</ComboBoxItem>
+                <!-- Windows -->
+                <CheckBox x:Name="WindowsCheckBox" Grid.Row="1" VerticalAlignment="Center" Checked="EvaluateButtonEnabledState" Unchecked="EvaluateButtonEnabledState" />
+                <ComboBox x:Name="WindowsFx" Grid.Row="1" IsEnabled="{Binding IsChecked, ElementName=WindowsCheckBox, Mode=OneWay}">
+                    <ComboBoxItem Tag="win8">Windows 8</ComboBoxItem>
+                    <ComboBoxItem Tag="win81">Windows 8.1</ComboBoxItem>
                 </ComboBox>
 
                 <!-- Windows Phone Silverlight -->
@@ -73,11 +73,11 @@
                     <ComboBoxItem Tag="wp81">Windows Phone Silverlight 8.1 and higher</ComboBoxItem>
                 </ComboBox>
 
-                <!-- Windows -->
-                <CheckBox x:Name="WindowsCheckBox" Grid.Row="3" VerticalAlignment="Center" Checked="EvaluateButtonEnabledState" Unchecked="EvaluateButtonEnabledState" />
-                <ComboBox x:Name="WindowsFx" Grid.Row="3" IsEnabled="{Binding IsChecked, ElementName=WindowsCheckBox, Mode=OneWay}">
-                    <ComboBoxItem Tag="win8">Windows 8</ComboBoxItem>
-                    <ComboBoxItem Tag="win81">Windows 8.1</ComboBoxItem>
+                <!-- Silverlight -->
+                <CheckBox x:Name="SilverlightCheckBox" Grid.Row="3" VerticalAlignment="Center" Checked="EvaluateButtonEnabledState" Unchecked="EvaluateButtonEnabledState" />
+                <ComboBox x:Name="SilverlightFx" Grid.Row="3" IsEnabled="{Binding IsChecked, ElementName=SilverlightCheckBox, Mode=OneWay}">
+                    <ComboBoxItem Tag="sl4">Silverlight 4 and higher</ComboBoxItem>
+                    <ComboBoxItem Tag="sl5">Silverlight 5</ComboBoxItem>
                 </ComboBox>
 
                 <!-- Windows Phone  -->

--- a/PackageExplorer/PortableLibraryDialog.xaml.cs
+++ b/PackageExplorer/PortableLibraryDialog.xaml.cs
@@ -14,7 +14,7 @@ namespace PackageExplorer
 
         public string GetSelectedFrameworkName()
         {
-            var comboBoxes = new ComboBox[] { NetFx, SilverlightFx, WPFx };
+            var comboBoxes = new ComboBox[] { NetFx, SilverlightFx, WPSLFx };
 
             var builder = new StringBuilder();
             for (int i = 0; i < comboBoxes.Length; i++)
@@ -53,7 +53,7 @@ namespace PackageExplorer
 
         private void EvaluateButtonEnabledState(object sender, RoutedEventArgs e)
         {
-            var _allCheckBoxes = new CheckBox[] { NetCheckBox, SilverlightCheckBox, WindowsCheckBox, WPCheckBox };
+            var _allCheckBoxes = new CheckBox[] { NetCheckBox, SilverlightCheckBox, WindowsCheckBox, WPSLCheckBox };
             var count = _allCheckBoxes.Count(p => p.IsChecked == true);
             OKButton.IsEnabled = count >= 2;
         }

--- a/PackageExplorer/PortableLibraryDialog.xaml.cs
+++ b/PackageExplorer/PortableLibraryDialog.xaml.cs
@@ -32,6 +32,11 @@ namespace PackageExplorer
                 builder.Append(((ComboBoxItem)comboBoxes[i].SelectedItem).Tag);
             }
 
+            if (WindowsPhoneCheckBox.IsChecked ?? false)
+            {
+                builder.Append("+wpa81");
+            }
+
             builder.Insert(0, "portable-");
             return builder.ToString();
         }
@@ -48,7 +53,7 @@ namespace PackageExplorer
 
         private void EvaluateButtonEnabledState(object sender, RoutedEventArgs e)
         {
-            var _allCheckBoxes = new CheckBox[] { NetCheckBox, SilverlightCheckBox, WindowsCheckBox, WPSLCheckBox };
+            var _allCheckBoxes = new CheckBox[] { NetCheckBox, SilverlightCheckBox, WindowsCheckBox, WPSLCheckBox, WindowsPhoneCheckBox };
             var count = _allCheckBoxes.Count(p => p.IsChecked == true);
             OKButton.IsEnabled = count >= 2;
         }

--- a/PackageExplorer/PortableLibraryDialog.xaml.cs
+++ b/PackageExplorer/PortableLibraryDialog.xaml.cs
@@ -14,7 +14,7 @@ namespace PackageExplorer
 
         public string GetSelectedFrameworkName()
         {
-            var comboBoxes = new ComboBox[] { NetFx, SilverlightFx, WPSLFx };
+            var comboBoxes = new ComboBox[] { NetFx, SilverlightFx, WPSLFx, WindowsFx };
 
             var builder = new StringBuilder();
             for (int i = 0; i < comboBoxes.Length; i++)
@@ -30,11 +30,6 @@ namespace PackageExplorer
                 }
 
                 builder.Append(((ComboBoxItem)comboBoxes[i].SelectedItem).Tag);
-            }
-
-            if (WindowsCheckBox.IsChecked ?? false)
-            {
-                builder.Append("+win8");
             }
 
             builder.Insert(0, "portable-");


### PR DESCRIPTION
Updated the portable chooser as per #44. We should now be covered up to PCL Profile 344 as per [Profiles.](https://portablelibraryprofiles.stephencleary.com/)

fixes  #44