### PR TITLE
#211 Sets parent first to force a path update.

### DIFF
--- a/PackageViewModel/PackagePart/PackageFolder.cs
+++ b/PackageViewModel/PackagePart/PackageFolder.cs
@@ -137,8 +137,8 @@ namespace PackageExplorerViewModel
 
         private void Attach(PackagePart child)
         {
-            Children.Add(child);
             child.Parent = this;
+            Children.Add(child);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #211 - Now updates the parent first to update the path so the compare works correctly. Also means items will be put back in alphabetical order.