### PR TITLE
Add information about referenced assemblies to UI

### DIFF
--- a/CodeExecutor/AppDomainWorker.cs
+++ b/CodeExecutor/AppDomainWorker.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 namespace CodeExecutor
@@ -90,6 +91,18 @@ namespace CodeExecutor
                 catch (Exception)
                 {
                     // if an exception occurs when loading custom attributes, just ignore
+                }
+
+                try
+                {
+                    data[AssemblyMetaData.ReferencedAssembliesKey] = string.Join(
+                        Environment.NewLine,
+                        assembly.GetReferencedAssemblies().OrderBy(assName => assName.Name)
+                    );
+                }
+                catch
+                {
+                    // Ignore if unable to obtain referenced assemblies
                 }
             }
 

--- a/CodeExecutor/AssemblyMetaData.cs
+++ b/CodeExecutor/AssemblyMetaData.cs
@@ -14,6 +14,8 @@ namespace CodeExecutor
     [Serializable]
     public class AssemblyMetaData : Dictionary<string, string>
     {
+        public const string ReferencedAssembliesKey = "Referenced assemblies";
+
         public AssemblyMetaData()
         {
         }

--- a/PackageExplorer/MefServices/AssemblyFileViewer.cs
+++ b/PackageExplorer/MefServices/AssemblyFileViewer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -32,7 +33,12 @@ namespace PackageExplorer
 
                 if (assemblyData != null)
                 {
-                    foreach (var data in assemblyData.OrderBy(d => d.Key))
+                    var orderedAssemblyDataEntries = assemblyData
+                        // Put information about referenced assemblies at the end.
+                        .OrderBy(d => d.Key.Equals(AssemblyMetaData.ReferencedAssembliesKey, StringComparison.Ordinal))
+                        .ThenBy(d => d.Key);
+
+                    foreach (var data in orderedAssemblyDataEntries)
                     {
                         var label = new TextBlock
                         {


### PR DESCRIPTION
I often need information about referenced assemblies when I review assemblies in NuGet packages. I've extended tool's UI to obtain this information and display it at the end:

![image](https://user-images.githubusercontent.com/1074182/29357406-19de58fa-8280-11e7-9fb7-61e690db0aab.png)

Let me know if you have any concerns/wishes regarding the suggested functionality.