### PR TITLE
Read assembly attributes for .NET Core and other runtime assemblies

### DIFF
--- a/CodeExecutor/AppDomainWorker.cs
+++ b/CodeExecutor/AppDomainWorker.cs
@@ -54,7 +54,7 @@ namespace CodeExecutor
                 return data;
             }
 
-            var assembly = Assembly.Load(assemblyName);
+            var assembly = Assembly.ReflectionOnlyLoadFrom(assemblyPath);
             if (assembly != null)
             {
 

--- a/CodeExecutor/RemoteCodeExecutor.cs
+++ b/CodeExecutor/RemoteCodeExecutor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace CodeExecutor
 {
@@ -48,6 +49,11 @@ namespace CodeExecutor
 
                 var worker = (AppDomainWorker)domain.CreateInstanceFromAndUnwrap(
                     Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "CodeExecutor.dll"), "CodeExecutor.AppDomainWorker");
+
+                var loadedAssemblyNames = AppDomain.CurrentDomain.GetAssemblies()
+                    .Select(x => x.GetName())
+                    .ToArray();
+                worker.SetupAssemblyLoadHook(loadedAssemblyNames);
 
                 workerAction(worker);
             }


### PR DESCRIPTION
Currently tool is unable to read assembly attributes if assembly targets some versions of the .NET Standard runtime. Consider the [AutoFixture 4.0 RC1](https://www.nuget.org/packages/AutoFixture/4.0.0-rc1) package as an example. If you select assembly targeting the .NET Standard, tool will not show the attributes.

I've adjusted the logic to perform more robust dependencies lookup. Also I use `Assembly.ReflectionOnlyLoadFrom(assemblyPath)` to load the assembly as this is the [advised by MS](https://docs.microsoft.com/en-us/dotnet/framework/reflection-and-codedom/how-to-load-assemblies-into-the-reflection-only-context) way.

Now it seems to work for all the packages I've tested.

@304NotModified @onovotny Please take a look and let me know if you see any issues with the PR.