### PR TITLE
add .NET 4.7 + 4.71, remove 4.6.3

### DIFF
--- a/PackageExplorer/PackageViewer.xaml.cs
+++ b/PackageExplorer/PackageViewer.xaml.cs
@@ -180,7 +180,8 @@ namespace PackageExplorer
                         "v4.6", "net46",
                         "v4.6.1", "net461",
                         "v4.6.2", "net462",
-                        "v4.6.3", "net463",
+                        "v4.7", "net47",
+                        "v4.7.1", "net471",
                     }
                 }
             };


### PR DESCRIPTION
or is there a 4.6.3?

(see https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Frameworks/DefaultFrameworkMappings.cs)


@onovotny what's the next version number? 

fixes https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/issues/206