### PR TITLE
Added an option to the publish window to use Credentials.

### DIFF
--- a/PackageExplorer/MefServices/SettingsManager.cs
+++ b/PackageExplorer/MefServices/SettingsManager.cs
@@ -122,6 +122,17 @@ namespace PackageExplorer
                 Settings.Default.PublishAsUnlisted = value;
             }
         }
+        public bool UseApiKey
+        {
+            get
+            {
+                return Settings.Default.UseApiKey;
+            }
+            set
+            {
+                Settings.Default.UseApiKey = value;
+            }
+        }
 
         #endregion
     }

--- a/PackageExplorer/Properties/Settings.Designer.cs
+++ b/PackageExplorer/Properties/Settings.Designer.cs
@@ -271,5 +271,17 @@ namespace PackageExplorer.Properties {
                 this["AutoLoadPackages"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool UseApiKey {
+            get {
+                return ((bool)(this["UseApiKey"]));
+            }
+            set {
+                this["UseApiKey"] = value;
+            }
+        }
     }
 }

--- a/PackageExplorer/Properties/Settings.settings
+++ b/PackageExplorer/Properties/Settings.settings
@@ -65,5 +65,8 @@
     <Setting Name="AutoLoadPackages" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="UseApiKey" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/PackageExplorer/PublishPackageWindow.xaml
+++ b/PackageExplorer/PublishPackageWindow.xaml
@@ -57,31 +57,44 @@
             </ComboBox>
         </DockPanel>
 
-        <!-- Publish key -->
+        <!-- Publish Auth type-->
         <DockPanel DockPanel.Dock="Top" Margin="7,0,10,5">
-            <Label DockPanel.Dock="Left" Target="{Binding ElementName=PublishKey}" Content="Publish _key:" Width="75" />
-            <TextBox x:Name="PublishKey" VerticalContentAlignment="Center" IsEnabled="{Binding CanPublish}" Margin="0" Text="{Binding PublishKey}">
-            </TextBox>
-        </DockPanel>
-        <!-- Publish Key type-->
-        <DockPanel DockPanel.Dock="Top" Margin="7,0,10,5">
-            <Label DockPanel.Dock="Left" Content="Key type:" Width="75" />
+            <Label DockPanel.Dock="Left" Content="Auth type:" Width="75" />
             <RadioButton x:Name="UseApiKey" 
-                         GroupName="KeyType" 
+                         GroupName="AuthType" 
                          IsEnabled="{Binding CanPublish}" 
                          VerticalAlignment="Center" 
                          IsChecked="{Binding UseApiKey}" 
                          Content="API Key" 
-                         ToolTip="Use this when only an API Key is required"
+                         ToolTip="Use this when only an API Key is required" Checked="UseApiKey_Checked"
                          />
-            <RadioButton x:Name="UseAccessToken" 
-                         GroupName="KeyType" 
+            <RadioButton x:Name="UseCredentials" 
+                         GroupName="AuthType" 
                          IsEnabled="{Binding CanPublish}" 
-                         IsChecked="{Binding UseAccessToken}" 
+                         IsChecked="{Binding UseCredentials}" 
                          VerticalAlignment="Center" 
-                         Content="Personal Access Token" 
-                         ToolTip="Use this when a PAT is used for credentials" Margin="10,0,0,0"
+                         Content="Credentials" 
+                         ToolTip="Use credentials are required" Margin="10,0,0,0" Checked="UseCredentials_Checked"
                          />
+        </DockPanel>
+        <!-- Publish key -->
+        <DockPanel x:Name="PanelApiKey" DockPanel.Dock="Top" Margin="7,0,10,5">
+            <Label DockPanel.Dock="Left" Target="{Binding ElementName=PublishKey}" Content="Publish _key:" Width="75" />
+            <TextBox x:Name="PublishKey" VerticalContentAlignment="Center" IsEnabled="{Binding CanPublish}" Margin="0" Text="{Binding PublishKey}">
+            </TextBox>
+        </DockPanel>
+        <!-- Publish key -->
+        <DockPanel x:Name="PanelCredentials" DockPanel.Dock="Top" Margin="0,0,0,0">
+            <DockPanel DockPanel.Dock="Top" Margin="7,0,10,5">
+                <Label DockPanel.Dock="Left" Target="{Binding ElementName=PublishCredentialUsername}" Content="_Username:" Width="75" />
+                <TextBox x:Name="PublishCredentialUsername" VerticalContentAlignment="Center" IsEnabled="{Binding CanPublish}" Margin="0" Text="{Binding PublishCredentialUsername}">
+                </TextBox>
+            </DockPanel>
+            <DockPanel DockPanel.Dock="Top" Margin="7,0,10,5">
+                <Label DockPanel.Dock="Left" Target="{Binding ElementName=PublishCredentialPassword}" Content="_Password:" Width="75" />
+                <PasswordBox x:Name="PublishCredentialPassword" VerticalContentAlignment="Center" IsEnabled="{Binding CanPublish}" Margin="0" PasswordChanged="PublishCredentialPassword_PasswordChanged">
+                </PasswordBox>
+            </DockPanel>
         </DockPanel>
         <CheckBox Margin="10,5,0,5" VerticalContentAlignment="Center" IsChecked="{Binding AppendV2ApiToUrl, BindingGroupName=Nothing, Mode=TwoWay}" DockPanel.Dock="Top" IsEnabled="{Binding CanPublish}" HorizontalAlignment="Left" Content="Append 'api/v2/package' to publish url" ToolTip="Check this for publishing to NuGet.org."/>
 
@@ -100,7 +113,7 @@
                     <Button.IsEnabled>
                         <MultiBinding Converter="{StaticResource andConverter}">
                             <Binding Path="Text" ElementName="PublishUrl" Converter="{StaticResource nullToBoolConverter}" />
-                            <Binding Path="Text" ElementName="PublishKey" Converter="{StaticResource nullToBoolConverter}" />
+                            <Binding Path="IsAuthSet" />
                             <Binding Path="CanPublish" />
                         </MultiBinding>
                     </Button.IsEnabled>

--- a/PackageExplorer/PublishPackageWindow.xaml
+++ b/PackageExplorer/PublishPackageWindow.xaml
@@ -74,7 +74,7 @@
                          Content="API Key" 
                          ToolTip="Use this when only an API Key is required"
                          />
-            <RadioButton x:Name="UsePAT" 
+            <RadioButton x:Name="UseAccessToken" 
                          GroupName="KeyType" 
                          IsEnabled="{Binding CanPublish}" 
                          IsChecked="{Binding UseAccessToken}" 

--- a/PackageExplorer/PublishPackageWindow.xaml
+++ b/PackageExplorer/PublishPackageWindow.xaml
@@ -63,6 +63,26 @@
             <TextBox x:Name="PublishKey" VerticalContentAlignment="Center" IsEnabled="{Binding CanPublish}" Margin="0" Text="{Binding PublishKey}">
             </TextBox>
         </DockPanel>
+        <!-- Publish Key type-->
+        <DockPanel DockPanel.Dock="Top" Margin="7,0,10,5">
+            <Label DockPanel.Dock="Left" Content="Key type:" Width="75" />
+            <RadioButton x:Name="UseApiKey" 
+                         GroupName="KeyType" 
+                         IsEnabled="{Binding CanPublish}" 
+                         VerticalAlignment="Center" 
+                         IsChecked="{Binding UseApiKey}" 
+                         Content="API Key" 
+                         ToolTip="Use this when only an API Key is required"
+                         />
+            <RadioButton x:Name="UsePAT" 
+                         GroupName="KeyType" 
+                         IsEnabled="{Binding CanPublish}" 
+                         IsChecked="{Binding UseAccessToken}" 
+                         VerticalAlignment="Center" 
+                         Content="Personal Access Token" 
+                         ToolTip="Use this when a PAT is used for credentials" Margin="10,0,0,0"
+                         />
+        </DockPanel>
         <CheckBox Margin="10,5,0,5" VerticalContentAlignment="Center" IsChecked="{Binding AppendV2ApiToUrl, BindingGroupName=Nothing, Mode=TwoWay}" DockPanel.Dock="Top" IsEnabled="{Binding CanPublish}" HorizontalAlignment="Left" Content="Append 'api/v2/package' to publish url" ToolTip="Check this for publishing to NuGet.org."/>
 
         <!-- Publish as unlisted flag -->

--- a/PackageExplorer/PublishPackageWindow.xaml.cs
+++ b/PackageExplorer/PublishPackageWindow.xaml.cs
@@ -20,9 +20,45 @@ namespace PackageExplorer
             bool isValid = DialogBindingGroup.UpdateSources();
             if (isValid)
             {
-                var viewModel = (PublishPackageViewModel) DataContext;
+                var viewModel = (PublishPackageViewModel)DataContext;
+                if (viewModel.UseCredentials.HasValue && viewModel.UseCredentials.Value)
+                {
+                    viewModel.PublishCredentialPassword = PublishCredentialPassword.Password;
+                }
                 await viewModel.PushPackage();
             }
+        }
+
+        private void PublishCredentialPassword_PasswordChanged(object sender, RoutedEventArgs e)
+        {
+            var viewModel = (PublishPackageViewModel)DataContext;
+            if (viewModel.UseCredentials.HasValue && viewModel.UseCredentials.Value)
+            {
+                viewModel.PublishCredentialPassword = PublishCredentialPassword.Password;
+            }
+        }
+
+        private void UseCredentials_Checked(object sender, RoutedEventArgs e)
+        {
+            var viewModel = (PublishPackageViewModel)DataContext;
+            viewModel.UseCredentials = true;
+            viewModel.UseApiKey = false;
+            viewModel.PublishKey = null;
+
+            PanelApiKey.Visibility = Visibility.Collapsed;
+            PanelCredentials.Visibility = Visibility.Visible;
+        }
+
+        private void UseApiKey_Checked(object sender, RoutedEventArgs e)
+        {
+            var viewModel = (PublishPackageViewModel)DataContext;
+            viewModel.UseApiKey = true;
+            viewModel.UseCredentials = false;
+            viewModel.PublishCredentialUsername = null;
+            viewModel.PublishCredentialPassword = null;
+
+            PanelCredentials.Visibility = Visibility.Collapsed;
+            PanelApiKey.Visibility = Visibility.Visible;
         }
     }
 }

--- a/PackageExplorer/PublishPackageWindow.xaml.cs
+++ b/PackageExplorer/PublishPackageWindow.xaml.cs
@@ -24,10 +24,5 @@ namespace PackageExplorer
                 await viewModel.PushPackage();
             }
         }
-
-        private void UsePAT_ToolTipOpening(object sender, System.Windows.Controls.ToolTipEventArgs e)
-        {
-
-        }
     }
 }

--- a/PackageExplorer/PublishPackageWindow.xaml.cs
+++ b/PackageExplorer/PublishPackageWindow.xaml.cs
@@ -24,5 +24,10 @@ namespace PackageExplorer
                 await viewModel.PushPackage();
             }
         }
+
+        private void UsePAT_ToolTipOpening(object sender, System.Windows.Controls.ToolTipEventArgs e)
+        {
+
+        }
     }
 }

--- a/PackageExplorer/app.config
+++ b/PackageExplorer/app.config
@@ -17,10 +17,10 @@
                 <value>https://nuget.org/api/v2/</value>
             </setting>
             <setting name="WindowPlacement" serializeAs="String">
-                <value/>
+                <value />
             </setting>
             <setting name="PublishPrivateKey" serializeAs="String">
-                <value/>
+                <value />
             </setting>
             <setting name="PublishPackageLocation" serializeAs="String">
                 <value>https://nuget.org</value>
@@ -59,6 +59,9 @@
                 <value>True</value>
             </setting>
             <setting name="AutoLoadPackages" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="UseApiKey" serializeAs="String">
                 <value>True</value>
             </setting>
         </PackageExplorer.Properties.Settings>

--- a/PackageViewModel/PublishPackage/PublishPackageViewModel.cs
+++ b/PackageViewModel/PublishPackage/PublishPackageViewModel.cs
@@ -24,7 +24,6 @@ namespace PackageExplorerViewModel
         private bool? _publishAsUnlisted = true;
         private bool? _appendV2ApiToUrl = true;
         private bool? _useApiKey = true;
-        private bool? _unlistPreviousVersions = false;
         private string _selectedPublishItem;
         private bool _showProgress;
         private string _status;
@@ -43,7 +42,6 @@ namespace PackageExplorerViewModel
             SelectedPublishItem = _mruSourceManager.ActivePackageSource;
             PublishAsUnlisted = _settingsManager.PublishAsUnlisted;
             UseApiKey = _settingsManager.UseApiKey;
-            UnlistPreviousVersions = false;
         }
 
         public string PublishKey
@@ -54,7 +52,7 @@ namespace PackageExplorerViewModel
                 if (_publishKey != value)
                 {
                     _publishKey = value;
-                    OnPropertyChanged("PublishKey");
+                    OnPropertyChanged(nameof(PublishKey));
                 }
             }
         }
@@ -68,7 +66,7 @@ namespace PackageExplorerViewModel
                 if (_mruSourceManager.ActivePackageSource != value)
                 {
                     _mruSourceManager.ActivePackageSource = value;
-                    OnPropertyChanged("PublishUrl");
+                    OnPropertyChanged(nameof(PublishUrl));
                 }
             }
         }
@@ -81,7 +79,7 @@ namespace PackageExplorerViewModel
                 if (_selectedPublishItem != value)
                 {
                     _selectedPublishItem = value;
-                    OnPropertyChanged("SelectedPublishItem");
+                    OnPropertyChanged(nameof(SelectedPublishItem));
 
                     if (value != null)
                     {
@@ -115,7 +113,7 @@ namespace PackageExplorerViewModel
                 if (_publishAsUnlisted != value)
                 {
                     _publishAsUnlisted = value;
-                    OnPropertyChanged("PublishAsUnlisted");
+                    OnPropertyChanged(nameof(PublishAsUnlisted));
                 }
             }
         }
@@ -127,7 +125,7 @@ namespace PackageExplorerViewModel
                 if (_useApiKey != value)
                 {
                     _useApiKey = value;
-                    OnPropertyChanged("UseApiKey");
+                    OnPropertyChanged(nameof(UseApiKey));
                 }
             }
         }
@@ -149,19 +147,7 @@ namespace PackageExplorerViewModel
                 if (_appendV2ApiToUrl != value)
                 {
                     _appendV2ApiToUrl = value;
-                    OnPropertyChanged("AppendV2ApiToUrl");
-                }
-            }
-        }
-        public bool? UnlistPreviousVersions
-        {
-            get { return _unlistPreviousVersions; }
-            set
-            {
-                if (_unlistPreviousVersions != value)
-                {
-                    _unlistPreviousVersions = value;
-                    OnPropertyChanged("UnlistPreviousVersions");
+                    OnPropertyChanged(nameof(AppendV2ApiToUrl));
                 }
             }
         }
@@ -184,7 +170,7 @@ namespace PackageExplorerViewModel
                 if (_hasError != value)
                 {
                     _hasError = value;
-                    OnPropertyChanged("HasError");
+                    OnPropertyChanged(nameof(HasError));
                 }
             }
         }
@@ -197,7 +183,7 @@ namespace PackageExplorerViewModel
                 if (_showProgress != value)
                 {
                     _showProgress = value;
-                    OnPropertyChanged("ShowProgress");
+                    OnPropertyChanged(nameof(ShowProgress));
                 }
             }
         }
@@ -210,7 +196,7 @@ namespace PackageExplorerViewModel
                 if (_canPublish != value)
                 {
                     _canPublish = value;
-                    OnPropertyChanged("CanPublish");
+                    OnPropertyChanged(nameof(CanPublish));
                 }
             }
         }
@@ -236,7 +222,7 @@ namespace PackageExplorerViewModel
                 if (_status != value)
                 {
                     _status = value;
-                    OnPropertyChanged("Status");
+                    OnPropertyChanged(nameof(Status));
                 }
             }
         }

--- a/PackageViewModel/PublishPackage/PublishPackageViewModel.cs
+++ b/PackageViewModel/PublishPackage/PublishPackageViewModel.cs
@@ -68,7 +68,7 @@ namespace PackageExplorerViewModel
                 if (_publishCredentialUsername != value)
                 {
                     _publishCredentialUsername = value;
-                    OnPropertyChanged("PublishCredentialUsername");
+                    OnPropertyChanged(nameof(PublishCredentialUsername));
                     CheckIfAuthIsSet();
                 }
             }
@@ -81,7 +81,7 @@ namespace PackageExplorerViewModel
                 if (_publishCredentialPassword != value)
                 {
                     _publishCredentialPassword = value;
-                    OnPropertyChanged("PublishCredentialPassword");
+                    OnPropertyChanged(nameof(PublishCredentialPassword));
                     CheckIfAuthIsSet();
                 }
             }

--- a/PackageViewModel/PublishPackage/PublishPackageViewModel.cs
+++ b/PackageViewModel/PublishPackage/PublishPackageViewModel.cs
@@ -23,6 +23,8 @@ namespace PackageExplorerViewModel
         private string _publishKey;
         private bool? _publishAsUnlisted = true;
         private bool? _appendV2ApiToUrl = true;
+        private bool? _useApiKey = true;
+        private bool? _unlistPreviousVersions = false;
         private string _selectedPublishItem;
         private bool _showProgress;
         private string _status;
@@ -40,6 +42,8 @@ namespace PackageExplorerViewModel
             _packageFilePath = viewModel.GetCurrentPackageTempFile();
             SelectedPublishItem = _mruSourceManager.ActivePackageSource;
             PublishAsUnlisted = _settingsManager.PublishAsUnlisted;
+            UseApiKey = _settingsManager.UseApiKey;
+            UnlistPreviousVersions = false;
         }
 
         public string PublishKey
@@ -115,6 +119,27 @@ namespace PackageExplorerViewModel
                 }
             }
         }
+        public bool? UseApiKey
+        {
+            get { return _useApiKey; }
+            set
+            {
+                if (_useApiKey != value)
+                {
+                    _useApiKey = value;
+                    OnPropertyChanged("UseApiKey");
+                }
+            }
+        }
+        public bool? UseAccessToken
+
+        {
+            get { return !UseApiKey; }
+            set
+            {
+                UseApiKey = !value;
+            }
+        }
 
         public bool? AppendV2ApiToUrl
         {
@@ -128,7 +153,19 @@ namespace PackageExplorerViewModel
                 }
             }
         }
-        
+        public bool? UnlistPreviousVersions
+        {
+            get { return _unlistPreviousVersions; }
+            set
+            {
+                if (_unlistPreviousVersions != value)
+                {
+                    _unlistPreviousVersions = value;
+                    OnPropertyChanged("UnlistPreviousVersions");
+                }
+            }
+        }
+
         public string Id
         {
             get { return _package.Id; }
@@ -238,8 +275,8 @@ namespace PackageExplorerViewModel
 
             try
             {
-                await GalleryServer.PushPackage(PublishKey, _packageFilePath, _package, PublishAsUnlisted ?? false, AppendV2ApiToUrl ?? false);
-
+                await GalleryServer.PushPackage(PublishKey, _packageFilePath, _package, PublishAsUnlisted ?? false, AppendV2ApiToUrl ?? false, UseApiKey ?? true);
+                
                 OnCompleted();
             }
             catch (Exception exception)
@@ -267,6 +304,7 @@ namespace PackageExplorerViewModel
         public void Dispose()
         {
             _settingsManager.PublishAsUnlisted = (bool)PublishAsUnlisted;
+            _settingsManager.UseApiKey = UseApiKey ?? true;
         }
     }
 }

--- a/PackageViewModel/Types/ISettingsManager.cs
+++ b/PackageViewModel/Types/ISettingsManager.cs
@@ -27,5 +27,6 @@ namespace NuGetPackageExplorer.Types
         string ReadApiKey(string source);
         void WriteApiKey(string source, string apiKey);
         bool PublishAsUnlisted { get; set; }
+        bool UseApiKey { get; set; }
     }
 }


### PR DESCRIPTION
Added an option to the publish window so we can choose to send the request with the default credentials or setting the Personal Access Token in the credential.

I think that this fixes #58 . Although I think that the sources should have a way to identify which kind of authentication to use.

I don't know if i broke any coding / design guideline as I didn't see any guide for contributing. I just followed some code.
Also, didn't find any unit test or test project to add tests to it.
Tested it against our VSTS and worked well.
Preview of the window:
![image](https://user-images.githubusercontent.com/822050/33359003-f8734676-d4aa-11e7-8d78-46ac3c8c95b8.png)
