### PR TITLE
Token workaround

### DIFF
--- a/Core/Utility/ManifestUtility.cs
+++ b/Core/Utility/ManifestUtility.cs
@@ -12,8 +12,8 @@ namespace NuGetPe.Utility
 {
     public static class ManifestUtility
     {
-        public const string TokenMetadataStart = "0.0.0-TOKENSTART.";
-        public const string TokenMetadataEnd = ".TOKENEND";
+        const string TokenMetadataStart = "0.0.0-TOKENSTART.";
+        const string TokenMetadataEnd = ".TOKENEND";
         static readonly Regex tokenRegex = new Regex(@"([$])(?:(?=(\\?))\2.)*?\1", RegexOptions.Compiled);
         static readonly Regex metadataRegEx = new Regex(@"0\.0\.0\-TOKENSTART\.([^.]+)\.TOKENEND", RegexOptions.Compiled);
 

--- a/Core/Utility/ManifestUtility.cs
+++ b/Core/Utility/ManifestUtility.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 
@@ -10,7 +11,10 @@ namespace NuGetPe.Utility
 {
     public static class ManifestUtility
     {
-        public const string TokenMetadata = "0.0.0+TOKEN999.";
+        public const string TokenMetadataStart = "0.0.0+TOKENSTART.";
+        public const string TokenMetadataEnd = ".TOKENEND";
+        static readonly Regex tokenRegex = new Regex(@"([$])(?:(?=(\\?))\2.)*?\1", RegexOptions.Compiled);
+        static readonly Regex metadataRegEx = new Regex(@"0\.0\.0\+TOKENSTART\.([^.]+)\.TOKENEND", RegexOptions.Compiled);
 
         public static Stream ReadManifest(string file)
         {
@@ -28,20 +32,52 @@ namespace NuGetPe.Utility
             var version = xdoc.Root.Descendants(ns + "version").FirstOrDefault();
             if (version != null)
             {
-                var val = version.Value;
-
-                // see if it's a token
-                if (val.Length >= 3 && val[0] == '$' && val[val.Length - 1] == '$')
-                {
-                    var token = val.Substring(1, val.Length - 2);
-                    version.Value = $"{TokenMetadata}{token}";
-                }
+                version.Value = ReplaceTokenWithMetadata(version.Value);
             }
 
             var ms = new MemoryStream();
             xdoc.Save(ms);
             ms.Position = 0;
             return ms;
+        }
+
+        /// <summary>
+        /// Goes from $token$ to a marker value with 0.0.0+TOKENSTART.token.TOKENEND
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static string ReplaceTokenWithMetadata(string value)
+        {
+            // see if it's a token
+
+            var matches = tokenRegex.Matches(value);
+            foreach (Match match in matches)
+            {
+                var token = match.Value.Substring(1, match.Value.Length - 2);
+                value = value.Replace(match.Value, $"{TokenMetadataStart}{token}{TokenMetadataEnd}");
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Goes from marker 0.0.0+TOKENSTART.token.TOKENEND to the token $token$
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static string ReplaceMetadataWithToken(string value)
+        {
+
+            // see if it's a token
+            var matches = metadataRegEx.Matches(value);
+
+            foreach (Match match in matches)
+            {
+                var token = match.Value.Substring(TokenMetadataStart.Length, match.Value.Length - TokenMetadataEnd.Length - TokenMetadataStart.Length);
+                value = value.Replace(match.Value, $"${token}$");
+            }
+
+            return value;
         }
 
         public static void SaveToStream(Stream sourceStream, Stream destinationStream)
@@ -55,19 +91,10 @@ namespace NuGetPe.Utility
             var version = xdoc.Root.Descendants(ns + "version").FirstOrDefault();
             if (version != null)
             {
-                var val = version.Value;
-
-                // see if it's a token
-                if (val.StartsWith(TokenMetadata))
-                {
-                    var token = val.Substring(TokenMetadata.Length);
-                    version.Value = $"${token}$";
-                }
+                version.Value = ReplaceMetadataWithToken(version.Value);
             }
 
             xdoc.Save(destinationStream);
         }
-
-        // public static 
     }
 }

--- a/Core/Utility/ManifestUtility.cs
+++ b/Core/Utility/ManifestUtility.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using NuGet.Versioning;
 
 namespace NuGetPe.Utility
 {
@@ -19,6 +20,14 @@ namespace NuGetPe.Utility
         public static Stream ReadManifest(string file)
         {
             return ReadManifest(File.OpenRead(file));
+        }
+
+
+        public static bool IsTokenized(this NuGetVersion version)
+        {
+            var labels = version.ReleaseLabels.ToList();
+
+            return labels.Count >= 3 && labels[0] == "TOKENSTART" && labels[labels.Count - 1] == "TOKENEND";
         }
 
         public static Stream ReadManifest(Stream stream)
@@ -61,6 +70,9 @@ namespace NuGetPe.Utility
         {
             // see if it's a token
 
+            if (value == null)
+                return value;
+
             var matches = tokenRegex.Matches(value);
             foreach (Match match in matches)
             {
@@ -78,6 +90,8 @@ namespace NuGetPe.Utility
         /// <returns></returns>
         public static string ReplaceMetadataWithToken(string value)
         {
+            if (value == null)
+                return value;
 
             // see if it's a token
             var matches = metadataRegEx.Matches(value);

--- a/Core/Utility/ManifestUtility.cs
+++ b/Core/Utility/ManifestUtility.cs
@@ -12,10 +12,12 @@ namespace NuGetPe.Utility
 {
     public static class ManifestUtility
     {
-        const string TokenMetadataStart = "0.0.0-TOKENSTART.";
-        const string TokenMetadataEnd = ".TOKENEND";
+        const string TokenStart = "TOKENSTART";
+        const string TokenEnd = "TOKENEND";
+        const string TokenMetadataStart = "0.0.0-" + TokenStart + ".";
+        const string TokenMetadataEnd = "." + TokenEnd;
         static readonly Regex tokenRegex = new Regex(@"([$])(?:(?=(\\?))\2.)*?\1", RegexOptions.Compiled);
-        static readonly Regex metadataRegEx = new Regex(@"0\.0\.0\-TOKENSTART\.([^.]+)\.TOKENEND", RegexOptions.Compiled);
+        static readonly Regex metadataRegEx = new Regex($@"0\.0\.0\-{TokenStart}\.([^.]+)\.{TokenEnd}", RegexOptions.Compiled);
 
         public static Stream ReadManifest(string file)
         {
@@ -27,7 +29,7 @@ namespace NuGetPe.Utility
         {
             var labels = version.ReleaseLabels.ToList();
 
-            return labels.Count >= 3 && labels[0] == "TOKENSTART" && labels[labels.Count - 1] == "TOKENEND";
+            return labels.Count >= 3 && labels[0] == TokenStart && labels[labels.Count - 1] == TokenEnd;
         }
 
         public static Stream ReadManifest(Stream stream)

--- a/Core/Utility/ManifestUtility.cs
+++ b/Core/Utility/ManifestUtility.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace NuGetPe.Utility
+{
+    public static class ManifestUtility
+    {
+        public const string TokenMetadata = "0.0.0+TOKEN999.";
+
+        public static Stream ReadManifest(string file)
+        {
+            return ReadManifest(File.OpenRead(file));
+        }
+
+        public static Stream ReadManifest(Stream stream)
+        {
+            // This method needs to replace tokens in version fields with a sentinel value
+            // since the NuGetVersion object model doesn't support it.
+            var xdoc = XDocument.Load(stream);
+            var ns = xdoc.Root.GetDefaultNamespace();
+
+            // Get the version node
+            var version = xdoc.Root.Descendants(ns + "version").FirstOrDefault();
+            if (version != null)
+            {
+                var val = version.Value;
+
+                // see if it's a token
+                if (val.Length >= 3 && val[0] == '$' && val[val.Length - 1] == '$')
+                {
+                    var token = val.Substring(1, val.Length - 2);
+                    version.Value = $"{TokenMetadata}{token}";
+                }
+            }
+
+            var ms = new MemoryStream();
+            xdoc.Save(ms);
+            ms.Position = 0;
+            return ms;
+        }
+
+        public static void SaveToStream(Stream sourceStream, Stream destinationStream)
+        {
+            // This method needs to replace tokens in version fields with a sentinel value
+            // since the NuGetVersion object model doesn't support it.
+            var xdoc = XDocument.Load(sourceStream);
+            var ns = xdoc.Root.GetDefaultNamespace();
+
+            // Get the version node
+            var version = xdoc.Root.Descendants(ns + "version").FirstOrDefault();
+            if (version != null)
+            {
+                var val = version.Value;
+
+                // see if it's a token
+                if (val.StartsWith(TokenMetadata))
+                {
+                    var token = val.Substring(TokenMetadata.Length);
+                    version.Value = $"${token}$";
+                }
+            }
+
+            xdoc.Save(destinationStream);
+        }
+
+        // public static 
+    }
+}

--- a/Core/Utility/ManifestUtility.cs
+++ b/Core/Utility/ManifestUtility.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using NuGet.Versioning;
 
-namespace NuGetPe.Utility
+namespace NuGetPe
 {
     public static class ManifestUtility
     {

--- a/PackageExplorer/Converters/NuGetVersionConverter.cs
+++ b/PackageExplorer/Converters/NuGetVersionConverter.cs
@@ -2,10 +2,8 @@
 using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
-using NuGet.Packaging;
 using NuGet.Versioning;
 using NuGetPe;
-using NuGetPe.Utility;
 
 namespace PackageExplorer
 {

--- a/PackageExplorer/Converters/NuGetVersionConverter.cs
+++ b/PackageExplorer/Converters/NuGetVersionConverter.cs
@@ -2,12 +2,14 @@
 using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
+using NuGet.Packaging;
 using NuGet.Versioning;
 using NuGetPe;
+using NuGetPe.Utility;
 
 namespace PackageExplorer
 {
-    [ValueConversion(typeof(NuGetVersionConverter), typeof(string))]
+    [ValueConversion(typeof(NuGetVersion), typeof(string))]
     public class NuGetVersionConverter : IValueConverter
     {
         #region IValueConverter Members
@@ -15,7 +17,7 @@ namespace PackageExplorer
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             var version =  value as NuGetVersion;
-            return version?.ToFullString();
+            return ManifestUtility.ReplaceMetadataWithToken(version?.ToFullString());
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
@@ -27,6 +29,7 @@ namespace PackageExplorer
             }
             else
             {
+                stringValue = ManifestUtility.ReplaceTokenWithMetadata(stringValue);
                 NuGetVersion version;
                 if (NuGetVersion.TryParse(stringValue, out version))
                 {

--- a/PackageExplorer/Converters/NuGetVersionPreReleaseConverter.cs
+++ b/PackageExplorer/Converters/NuGetVersionPreReleaseConverter.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+using NuGet.Versioning;
+using NuGetPe.Utility;
+
+namespace PackageExplorer
+{
+    [ValueConversion(typeof(NuGetVersion), typeof(Visibility))]
+    public class NuGetVersionPreReleaseConverter : IValueConverter
+    {
+        #region IValueConverter Members
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var version =  value as NuGetVersion;
+
+            if (version != null)
+            {
+                if (!version.IsTokenized() && version.IsPrerelease)
+                    return Visibility.Visible;
+            }
+
+            return Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+    }
+}

--- a/PackageExplorer/Converters/NuGetVersionPreReleaseConverter.cs
+++ b/PackageExplorer/Converters/NuGetVersionPreReleaseConverter.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
 using NuGet.Versioning;
-using NuGetPe.Utility;
+using NuGetPe;
 
 namespace PackageExplorer
 {

--- a/PackageExplorer/Converters/PackageDependencyConverter.cs
+++ b/PackageExplorer/Converters/PackageDependencyConverter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Data;
 using NuGet.Packaging.Core;
+using NuGetPe.Utility;
 
 namespace PackageExplorer
 {
@@ -15,7 +16,7 @@ namespace PackageExplorer
 
             var dependency = (PackageDependency)value;
             
-            return $"{dependency.Id} {dependency.VersionRange.PrettyPrint()}";
+            return $"{dependency.Id} {ManifestUtility.ReplaceMetadataWithToken(dependency.VersionRange.PrettyPrint())}";
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)

--- a/PackageExplorer/Converters/PackageDependencyConverter.cs
+++ b/PackageExplorer/Converters/PackageDependencyConverter.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Data;
 using NuGet.Packaging.Core;
-using NuGetPe.Utility;
+using NuGetPe;
 
 namespace PackageExplorer
 {

--- a/PackageExplorer/Converters/VersionSpecConverter.cs
+++ b/PackageExplorer/Converters/VersionSpecConverter.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
 using NuGet.Versioning;
+using NuGetPe.Utility;
 
 namespace PackageExplorer
 {
@@ -13,7 +14,7 @@ namespace PackageExplorer
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             var versionSpec = (VersionRange) value;
-            return versionSpec == null ? null : versionSpec.ToShortString();
+            return versionSpec == null ? null : ManifestUtility.ReplaceMetadataWithToken(versionSpec.ToShortString());
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
@@ -25,6 +26,8 @@ namespace PackageExplorer
             }
             else
             {
+                stringValue = ManifestUtility.ReplaceTokenWithMetadata(stringValue);
+
                 if (VersionRange.TryParse(stringValue, out VersionRange versionSpec))
                 {
                     return versionSpec;

--- a/PackageExplorer/Converters/VersionSpecConverter.cs
+++ b/PackageExplorer/Converters/VersionSpecConverter.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
 using NuGet.Versioning;
-using NuGetPe.Utility;
+using NuGetPe;
 
 namespace PackageExplorer
 {

--- a/PackageExplorer/MainWindow.xaml.cs
+++ b/PackageExplorer/MainWindow.xaml.cs
@@ -24,7 +24,6 @@ using Constants = NuGetPe.Constants;
 using LazyPackageCommand = System.Lazy<NuGetPackageExplorer.Types.IPackageCommand, NuGetPackageExplorer.Types.IPackageCommandMetadata>;
 using StringResources = PackageExplorer.Resources.Resources;
 using NuGet.Packaging;
-using NuGetPe.Utility;
 
 namespace PackageExplorer
 {

--- a/PackageExplorer/MainWindow.xaml.cs
+++ b/PackageExplorer/MainWindow.xaml.cs
@@ -24,6 +24,7 @@ using Constants = NuGetPe.Constants;
 using LazyPackageCommand = System.Lazy<NuGetPackageExplorer.Types.IPackageCommand, NuGetPackageExplorer.Types.IPackageCommandMetadata>;
 using StringResources = PackageExplorer.Resources.Resources;
 using NuGet.Packaging;
+using NuGetPe.Utility;
 
 namespace PackageExplorer
 {
@@ -148,8 +149,11 @@ namespace PackageExplorer
                 }
                 else if (extension.Equals(Constants.ManifestExtension, StringComparison.OrdinalIgnoreCase))
                 {
-                    var builder = new PackageBuilder(packagePath, null, false);
-                    package = builder.Build();
+                    using (var str = ManifestUtility.ReadManifest(packagePath))
+                    {
+                        var builder = new PackageBuilder(str, Path.GetDirectoryName(packagePath));
+                        package = builder.Build();
+                    }
                 }
 
                 if (package != null)

--- a/PackageExplorer/PackageViewer.xaml
+++ b/PackageExplorer/PackageViewer.xaml
@@ -39,6 +39,7 @@
             <self:FrameworkAssemblyReferenceDisplayConverter x:Key="FrameworkAssemblyReferenceDisplayConverter" />
             <self:NuGetVersionConverter x:Key="NuGetVersionConverter" />
             <self:CertificateToSubjectConverter x:Key="CertificateToSubjectConverter" />
+            <self:NuGetVersionPreReleaseConverter x:Key="NuGetVersionPreReleaseConverter" />
 
             <DataTemplate DataType="{x:Type core:PackageDependency}">
                 <TextBlock ToolTip="Open this package from online feed.">
@@ -237,7 +238,7 @@
                         <StackPanel Style="{StaticResource DetailMetadataStyle}">
                             <TextBlock Text="{x:Static resources:Resources.Dialog_VersionLabel}" Style="{StaticResource DetailMetadataLabelStyle}" />
                             <TextBlock Text="{Binding Version, Converter={StaticResource NuGetVersionConverter}}" Style="{StaticResource DetailMetadataValueStyle}" />
-                            <TextBlock Margin="3,0,0,0" Text="(prerelease)" Foreground="DarkRed" Visibility="{Binding Version.IsPrerelease, Mode=OneWay, Converter={StaticResource BooleanToVisConverter}}" />
+                            <TextBlock Margin="3,0,0,0" Text="(prerelease)" Foreground="DarkRed" Visibility="{Binding Version, Mode=OneWay, Converter={StaticResource NuGetVersionPreReleaseConverter}}" />
                         </StackPanel>
 
                         <!-- Publisher -->

--- a/PackageViewModel/Commands/SavePackageCommand.cs
+++ b/PackageViewModel/Commands/SavePackageCommand.cs
@@ -26,6 +26,8 @@ namespace PackageExplorerViewModel
         {
             var isSigned = ViewModel.IsSigned;
 
+            var hasTokens = ViewModel.IsTokenized;
+
             var action = parameter as string;
             if (action == SaveAsAction || action == SaveMetadataAction)
             {
@@ -33,8 +35,13 @@ namespace PackageExplorerViewModel
                 isSigned = false;    
             }
 
+            if (action == SaveMetadataAction)
+            {
+                // allowed for tokenized things
+                hasTokens = false;
+            }
 
-            return !isSigned && !ViewModel.IsInEditFileMode;
+            return !isSigned && !hasTokens && !ViewModel.IsInEditFileMode;
         }
 
         public event EventHandler CanExecuteChanged;

--- a/PackageViewModel/EditablePackageMetadata.cs
+++ b/PackageViewModel/EditablePackageMetadata.cs
@@ -3,15 +3,12 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
 using System.Windows.Input;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
-using NuGet.Packaging.Signing;
 using NuGet.Versioning;
 using NuGetPackageExplorer.Types;
 using NuGetPe;
-using NuGetPe.Utility;
 using PackageType = NuGet.Packaging.Core.PackageType;
 
 namespace PackageExplorerViewModel

--- a/PackageViewModel/EditablePackageMetadata.cs
+++ b/PackageViewModel/EditablePackageMetadata.cs
@@ -11,6 +11,7 @@ using NuGet.Packaging.Signing;
 using NuGet.Versioning;
 using NuGetPackageExplorer.Types;
 using NuGetPe;
+using NuGetPe.Utility;
 using PackageType = NuGet.Packaging.Core.PackageType;
 
 namespace PackageExplorerViewModel
@@ -571,7 +572,7 @@ namespace PackageExplorerViewModel
 
         public override string ToString()
         {
-            return Id + "." + Version;
+            return Id + "." + ManifestUtility.ReplaceMetadataWithToken(Version.ToFullString());
         }
 
         private string IsValid(string propertyName)

--- a/PackageViewModel/PackageViewModel.cs
+++ b/PackageViewModel/PackageViewModel.cs
@@ -11,7 +11,6 @@ using NuGetPe;
 using NuGetPackageExplorer.Types;
 using LazyPackageCommand = System.Lazy<NuGetPackageExplorer.Types.IPackageCommand, NuGetPackageExplorer.Types.IPackageCommandMetadata>;
 using NuGet.Packaging;
-using NuGetPe.Utility;
 
 namespace PackageExplorerViewModel
 {


### PR DESCRIPTION
Fixes #255 

Basically, this works if a token represents a full version string, but I think it’s possible to use a token anywhere in the string, like 3.3.0$versionsuffix$. This won't work in that case, but I don't think that's too common.

If there are any tokens in the versions, save package and publish commands are disabled since that's not a valid package. It can only be saved as a manifest.

Here's a nuspec I used for testing

```xml
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <id>MyPackage</id>
    <version>$version$</version>
    <title></title>
    <authors>oren</authors>
    <owners>oren</owners>
    <requireLicenseAcceptance>false</requireLicenseAcceptance>
    <description>My package description.</description>
    <dependencies>
      <group>
        <dependency id="foo" version="$versio1n$" />
        <dependency id="bar" version="$version$" />
        <dependency id="bb" version="[$version$, $version4$)" />
      </group>
      <group targetFramework=".NETFramework4.5">
        <dependency id="bb" version="4.5.0" />
      </group>
    </dependencies>
  </metadata>
  <files>
  </files>
</package>
```