### PR TITLE
Fix The DateTimeOffset specified cannot be converted into a Zip file timestamp

### DIFF
--- a/Core/Packages/PackageFileBase.cs
+++ b/Core/Packages/PackageFileBase.cs
@@ -63,6 +63,6 @@ namespace NuGetPe
             }
         }
 
-        public DateTimeOffset LastWriteTime => DateTimeOffset.MinValue;
+        public DateTimeOffset LastWriteTime { get; protected set; } = DateTimeOffset.MinValue;
     }
 }

--- a/Core/Packages/ZipPackageFile.cs
+++ b/Core/Packages/ZipPackageFile.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Compression;
 using System.IO.Packaging;
 using NuGet.Packaging;
 
@@ -10,11 +11,12 @@ namespace NuGetPe
     {
         private readonly Func<Stream> _streamFactory;
 
-        public ZipPackageFile(PackageArchiveReader reader, string path) 
-            : base(path.Replace('/', '\\'))
+        public ZipPackageFile(PackageArchiveReader reader, ZipArchiveEntry entry) 
+            : base(entry.FullName.Replace('/', '\\'))
         {
             Debug.Assert(reader != null, "reader should not be null");
-            _streamFactory = () => reader.GetStream(path);
+            LastWriteTime = entry.LastWriteTime;
+            _streamFactory = () => reader.GetStream(entry.FullName);
         }
 
         public override Stream GetStream()


### PR DESCRIPTION
remember LastWriteTime when loading the package

fixes https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/issues/269

tested on NLog 4.4.12