### PR TITLE
unescape zip file names

### DIFF
--- a/Core/Packages/ZipPackageFile.cs
+++ b/Core/Packages/ZipPackageFile.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
@@ -12,11 +12,23 @@ namespace NuGetPe
         private readonly Func<Stream> _streamFactory;
 
         public ZipPackageFile(PackageArchiveReader reader, ZipArchiveEntry entry) 
-            : base(entry.FullName.Replace('/', '\\'))
+            : base(UnescapePath(entry.FullName.Replace('/', '\\')))
         {
             Debug.Assert(reader != null, "reader should not be null");
             LastWriteTime = entry.LastWriteTime;
-            _streamFactory = () => reader.GetStream(entry.FullName);
+            _streamFactory = () => reader.GetStream(UnescapePath(entry.FullName));
+        }
+
+        // code copied from https://github.com/NuGet/NuGet.Client/blob/91023394890b1458ec0c5940128da73e04089869/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs#L36-L45
+        private static string UnescapePath(string path)
+        {
+            if (path != null
+                && path.IndexOf('%') > -1)
+            {
+                return Uri.UnescapeDataString(path);
+            }
+
+            return path;
         }
 
         public override Stream GetStream()


### PR DESCRIPTION
this was previously done by the PackageArchiveReader

fixes #327