### PR TITLE
use packageId for exact matches

### DIFF
--- a/PackageExplorer/MainWindow.xaml.cs
+++ b/PackageExplorer/MainWindow.xaml.cs
@@ -269,7 +269,7 @@ namespace PackageExplorer
             var parameter = (string)e.Parameter;
             if (!string.IsNullOrEmpty(parameter))
             {
-                parameter = "id:" + parameter;
+                parameter = "packageId:" + parameter;
             }
             await OpenPackageFromRepository(parameter);
         }


### PR DESCRIPTION
### NuGet V2
![image](https://user-images.githubusercontent.com/4009570/36349924-8552eaf6-148e-11e8-8579-eeda3282021e.png)

### NuGet V3
![image](https://user-images.githubusercontent.com/4009570/36349930-8d73ffe0-148e-11e8-9350-0a355835720d.png)

---

### MyGet V2
![image](https://user-images.githubusercontent.com/4009570/36349934-af49b6c8-148e-11e8-883e-f6f4fef7cd82.png)

### MyGet V3
![image](https://user-images.githubusercontent.com/4009570/36349936-bd6dede6-148e-11e8-94d2-623fabbd273d.png)

---

### VSTS V3
![image](https://user-images.githubusercontent.com/4009570/36350050-c3d204d6-1490-11e8-9a80-5993208e121c.png)
Does not work with neither `packageId` or `id`.

### VSTS V2
![image](https://user-images.githubusercontent.com/4009570/36350099-e10e803c-1491-11e8-8635-086352c9bafe.png)
Does not work with neither `packageId` or `id`.

---

### Local Feed
Does not work with neither `packageId` or `id`.

---

As suggested here https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/issues/348#issuecomment-366490686

fixes https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/issues/348