### PR TITLE
accept publish key or PAT in PublishDialog

### DIFF
--- a/PackageExplorer/App.xaml.cs
+++ b/PackageExplorer/App.xaml.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel.Composition;
+﻿using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -7,7 +6,6 @@ using System.Threading.Tasks;
 using System.Windows;
 using NuGet.Credentials;
 using NuGet.Protocol;
-using NuGetPackageExplorer.Types;
 using PackageExplorer.Properties;
 using PackageExplorerViewModel;
 using PackageExplorerViewModel.Types;
@@ -41,12 +39,10 @@ namespace PackageExplorer
 
         private async void Application_Startup(object sender, StartupEventArgs e)
         {
-            var credentialManagerProvider = new CredentialManagerProvider(Container.GetExport<ICredentialManager>());
-            var credentialDialogProvider = new CredentialDialogProvider(Container.GetExport<IUIServices>());
-
             HttpHandlerResourceV3.CredentialService = new CredentialService(new ICredentialProvider[] {
-                credentialManagerProvider,
-                credentialDialogProvider,
+                Container.GetExportedValue<CredentialManagerProvider>(),
+                Container.GetExportedValue<CredentialPublishProvider>(),
+                Container.GetExportedValue<CredentialDialogProvider>(),
             }, false);
             HttpHandlerResourceV3.CredentialsSuccessfullyUsed = (uri, credentials) => Container.GetExportedValue<ICredentialManager>().Add(credentials, uri);
 

--- a/PackageExplorer/PublishPackageWindow.xaml
+++ b/PackageExplorer/PublishPackageWindow.xaml
@@ -28,10 +28,10 @@
         </DockPanel.BindingGroup>
 
         <!-- Main instruction -->
-        <TextBlock DockPanel.Dock="Top" Text="Enter your publish key." FontSize="12pt" Margin="10,10,0,15" Foreground="{StaticResource TaskDialogMainInstructionBrush}" />
+        <TextBlock DockPanel.Dock="Top" Text="Enter your publish key or PAT." FontSize="12pt" Margin="10,10,0,15" Foreground="{StaticResource TaskDialogMainInstructionBrush}" />
 
         <!-- Secondary instruction -->
-        <TextBlock DockPanel.Dock="Top" Margin="10,0" Text="Provide the publish Url and the publish key associated with it." TextWrapping="Wrap" />
+        <TextBlock DockPanel.Dock="Top" Margin="10,0" Text="Provide the publish Url and the publish key or PAT associated with it." TextWrapping="Wrap" />
 
         <!-- Id & Version -->
         <TextBlock DockPanel.Dock="Top" Margin="10,10,10,0">
@@ -45,7 +45,7 @@
 
         <!-- Publish Url -->
         <DockPanel DockPanel.Dock="Top" Margin="7,8,10,5">
-            <Label DockPanel.Dock="Left" Target="{Binding ElementName=PublishUrl}" Content="Publish _Url:" Width="75" />
+            <Label DockPanel.Dock="Left" Target="{Binding ElementName=PublishUrl}" Content="Publish _Url:" Width="110" />
             <ComboBox x:Name="PublishUrl" ItemsSource="{Binding PublishSources}" IsReadOnly="False" IsEditable="True" VerticalContentAlignment="Center" SelectedItem="{Binding SelectedPublishItem, BindingGroupName=Random}" IsEnabled="{Binding CanPublish}">
                 <ComboBox.Text>
                     <Binding Path="PublishUrl">
@@ -59,8 +59,8 @@
 
         <!-- Publish key -->
         <DockPanel x:Name="PanelApiKey" DockPanel.Dock="Top" Margin="7,0,10,5">
-            <Label DockPanel.Dock="Left" Target="{Binding ElementName=PublishKey}" Content="Publish _key:" Width="75" />
-            <TextBox x:Name="PublishKey" VerticalContentAlignment="Center" IsEnabled="{Binding CanPublish}" Margin="0" Text="{Binding PublishKey}">
+            <Label DockPanel.Dock="Left" Target="{Binding ElementName=PublishKey}" Content="Publish _key or PAT:" Width="110" />
+            <TextBox x:Name="PublishKey" VerticalContentAlignment="Center" IsEnabled="{Binding CanPublish}" Margin="0" Text="{Binding PublishKeyOrPAT}">
             </TextBox>
         </DockPanel>
 

--- a/PackageExplorer/PublishPackageWindow.xaml
+++ b/PackageExplorer/PublishPackageWindow.xaml
@@ -28,7 +28,7 @@
         </DockPanel.BindingGroup>
 
         <!-- Main instruction -->
-        <TextBlock DockPanel.Dock="Top" Text="Enter your publish key or PAT." FontSize="12pt" Margin="10,10,0,15" Foreground="{StaticResource TaskDialogMainInstructionBrush}" />
+        <TextBlock DockPanel.Dock="Top" Text="Enter your publish key or PAT (Personal Access Token)." FontSize="12pt" Margin="10,10,0,15" Foreground="{StaticResource TaskDialogMainInstructionBrush}" />
 
         <!-- Secondary instruction -->
         <TextBlock DockPanel.Dock="Top" Margin="10,0" Text="Provide the publish Url and the publish key or PAT associated with it." TextWrapping="Wrap" />

--- a/PackageViewModel/CredentialDialogProvider.cs
+++ b/PackageViewModel/CredentialDialogProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel.Composition;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,13 +9,15 @@ using NuGetPackageExplorer.Types;
 
 namespace PackageExplorerViewModel
 {
+    [Export]
     public class CredentialDialogProvider : ICredentialProvider
     {
-        private readonly Lazy<IUIServices> _uiServices;
+        private readonly IUIServices _uiServices;
 
-        public CredentialDialogProvider(Lazy<IUIServices> uIServices)
+        [ImportingConstructor]
+        public CredentialDialogProvider(IUIServices uiServices)
         {
-            _uiServices = uIServices ?? throw new ArgumentNullException(nameof(uIServices)); 
+            _uiServices = uiServices ?? throw new ArgumentNullException(nameof(uiServices)); 
         }
 
         public string Id => "NPECredentialDialog";
@@ -29,9 +32,9 @@ namespace PackageExplorerViewModel
             bool success = false;
             NetworkCredential credential = null;
 
-            await _uiServices.Value.BeginInvoke(() =>
+            await _uiServices.BeginInvoke(() =>
             {
-                success = _uiServices.Value.OpenCredentialsDialog(uri.GetLeftPart(UriPartial.Authority), out credential);
+                success = _uiServices.OpenCredentialsDialog(uri.GetLeftPart(UriPartial.Authority), out credential);
             });
 
             cancellationToken.ThrowIfCancellationRequested();

--- a/PackageViewModel/CredentialManagerProvider.cs
+++ b/PackageViewModel/CredentialManagerProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel.Composition;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,11 +9,13 @@ using PackageExplorerViewModel.Types;
 
 namespace PackageExplorerViewModel
 {
+    [Export]
     public class CredentialManagerProvider : ICredentialProvider
     {
-        private readonly Lazy<ICredentialManager> _credentialManager;
+        private readonly ICredentialManager _credentialManager;
 
-        public CredentialManagerProvider(Lazy<ICredentialManager> credentialManager)
+        [ImportingConstructor]
+        public CredentialManagerProvider(ICredentialManager credentialManager)
         {
             _credentialManager = credentialManager ?? throw new ArgumentNullException(nameof(credentialManager));
         }
@@ -23,16 +26,16 @@ namespace PackageExplorerViewModel
         {
             if (isRetry)
             {
-                return Task.FromResult(new CredentialResponse(CredentialStatus.ProviderNotApplicable));
+                return Task.FromResult(new CredentialResponse(CredentialStatus.UserCanceled));
             }
 
-            var credentials = _credentialManager.Value.Get(uri);
+            var credentials = _credentialManager.Get(uri);
 
             if (credentials != null)
             {
                 return Task.FromResult(new CredentialResponse(credentials));
             }
-            return Task.FromResult(new CredentialResponse(CredentialStatus.ProviderNotApplicable));
+            return Task.FromResult(new CredentialResponse(CredentialStatus.UserCanceled));
         }
     }
 }

--- a/PackageViewModel/CredentialPublishProvider.cs
+++ b/PackageViewModel/CredentialPublishProvider.cs
@@ -1,0 +1,28 @@
+﻿using NuGet.Configuration;
+using NuGet.Credentials;
+using System;
+using System.ComponentModel.Composition;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PackageExplorerViewModel
+{
+    [Export]
+    public class CredentialPublishProvider : ICredentialProvider
+    {
+        public string Id => "NPECredentialPublish";
+
+        public string PersonalAccessToken { get; set; }
+
+        public Task<CredentialResponse> GetAsync(Uri uri, IWebProxy proxy, CredentialRequestType type, string message, bool isRetry, bool nonInteractive, CancellationToken cancellationToken)
+        {
+            if (!string.IsNullOrEmpty(PersonalAccessToken) && !isRetry)
+            {
+                return Task.FromResult(new CredentialResponse(new NetworkCredential(PersonalAccessToken, string.Empty)));
+            }
+
+            return Task.FromResult(new CredentialResponse(CredentialStatus.UserCanceled));
+        }
+    }
+}

--- a/PackageViewModel/PackageViewModel.cs
+++ b/PackageViewModel/PackageViewModel.cs
@@ -28,6 +28,7 @@ namespace PackageExplorerViewModel
         private readonly IList<Lazy<IPackageRule>> _packageRules;
         private readonly ISettingsManager _settingsManager;
         private readonly IUIServices _uiServices;
+        private readonly CredentialPublishProvider _credentialPublishProvider;
 
         private ICommand _addContentFileCommand;
         private ICommand _addContentFolderCommand;
@@ -70,14 +71,16 @@ namespace PackageExplorerViewModel
             IUIServices uiServices,
             IPackageEditorService editorService,
             ISettingsManager settingsManager,
+            CredentialPublishProvider credentialPublishProvider,
             IList<Lazy<IPackageContentViewer, IPackageContentViewerMetadata>> contentViewerMetadata,
             IList<Lazy<IPackageRule>> packageRules)
         {
-            _settingsManager = settingsManager ?? throw new ArgumentNullException("settingsManager");
-            _editorService = editorService ?? throw new ArgumentNullException("editorService");
-            _uiServices = uiServices ?? throw new ArgumentNullException("uiServices");
-            _mruManager = mruManager ?? throw new ArgumentNullException("mruManager");
-            _package = package ?? throw new ArgumentNullException("package");
+            _settingsManager = settingsManager ?? throw new ArgumentNullException(nameof(settingsManager));
+            _editorService = editorService ?? throw new ArgumentNullException(nameof(editorService));
+            _uiServices = uiServices ?? throw new ArgumentNullException(nameof(uiServices));
+            _mruManager = mruManager ?? throw new ArgumentNullException(nameof(mruManager));
+            _credentialPublishProvider = credentialPublishProvider ?? throw new ArgumentNullException(nameof(credentialPublishProvider));
+            _package = package ?? throw new ArgumentNullException(nameof(package));
             _contentViewerMetadata = contentViewerMetadata;
             _packageRules = packageRules;
 
@@ -720,6 +723,7 @@ namespace PackageExplorerViewModel
                 var publishPackageViewModel = new PublishPackageViewModel(
                     mruSourceManager,
                     _settingsManager,
+                    _credentialPublishProvider,
                     this);
                 _uiServices.OpenPublishDialog(publishPackageViewModel);
             }

--- a/PackageViewModel/PackageViewModelFactory.cs
+++ b/PackageViewModel/PackageViewModelFactory.cs
@@ -32,6 +32,9 @@ namespace PackageExplorerViewModel
         [Import]
         public ISettingsManager SettingsManager { get; set; }
 
+        [Import]
+        public CredentialPublishProvider CredentialPublishProvider { get; set; }
+
         [Import(typeof(IPluginManager))]
         public IPluginManager PluginManager { get; set; }
 
@@ -70,6 +73,7 @@ namespace PackageExplorerViewModel
                 UIServices,
                 EditorService.Value,
                 SettingsManager,
+                CredentialPublishProvider,
                 ContentViewerMetadata,
                 PackageRules);
         }


### PR DESCRIPTION
Publishing packages requires either a `Publish Key` or a `PAT` (Personal Access Token).
The implementation is not really nice. Maybe someone else has a good idea?

![image](https://user-images.githubusercontent.com/4009570/36356806-95834d62-14f7-11e8-89b0-014ea50aff35.png)

The UI currently always shows the abbrevation (PAT). Should the first occurrence be changed to `PAT (Personal Access Token)` ?