### PR TITLE
Use space to separate package id and version

### DIFF
--- a/PackageViewModel/EditablePackageMetadata.cs
+++ b/PackageViewModel/EditablePackageMetadata.cs
@@ -572,7 +572,7 @@ namespace PackageExplorerViewModel
 
         public override string ToString()
         {
-            return Id + "." + ManifestUtility.ReplaceMetadataWithToken(Version.ToFullString());
+            return Id + " " + ManifestUtility.ReplaceMetadataWithToken(Version.ToFullString());
         }
 
         private string IsValid(string propertyName)


### PR DESCRIPTION
Separating them with period doesn't make much sense to me, and it also leads to confusing window title for packages whose id ends with a number. E.g.:

![](https://user-images.githubusercontent.com/287848/36595924-3fd4647c-18a4-11e8-8bf1-cd9a6f6f7f93.png)
