### PR TITLE
reinitialize credential service after new credentials are added

### DIFF
--- a/PackageExplorer/App.xaml.cs
+++ b/PackageExplorer/App.xaml.cs
@@ -39,12 +39,12 @@ namespace PackageExplorer
 
         private async void Application_Startup(object sender, StartupEventArgs e)
         {
-            HttpHandlerResourceV3.CredentialService = new CredentialService(new ICredentialProvider[] {
-                Container.GetExportedValue<CredentialManagerProvider>(),
-                Container.GetExportedValue<CredentialPublishProvider>(),
-                Container.GetExportedValue<CredentialDialogProvider>(),
-            }, false);
-            HttpHandlerResourceV3.CredentialsSuccessfullyUsed = (uri, credentials) => Container.GetExportedValue<ICredentialManager>().Add(credentials, uri);
+            InitCredentialService();
+            HttpHandlerResourceV3.CredentialsSuccessfullyUsed = (uri, credentials) =>
+            {
+                Container.GetExportedValue<ICredentialManager>().Add(credentials, uri);
+                InitCredentialService();
+            };
 
             MigrateSettings();
 
@@ -60,6 +60,15 @@ namespace PackageExplorer
                     return;
                 }
             }
+        }
+
+        private void InitCredentialService()
+        {
+            HttpHandlerResourceV3.CredentialService = new CredentialService(new ICredentialProvider[] {
+                Container.GetExportedValue<CredentialManagerProvider>(),
+                Container.GetExportedValue<CredentialPublishProvider>(),
+                Container.GetExportedValue<CredentialDialogProvider>(),
+            }, nonInteractive: false);
         }
 
         private static void MigrateSettings()


### PR DESCRIPTION
because the CredentialService is caching the responses to detect retries
(it would be nicer if we could just clear the retry cache)

fixes #388 