### PR TITLE
fix plugin loading to support plugins targeting NPE >= 4

### DIFF
--- a/PackageExplorer/MefServices/PluginManager.cs
+++ b/PackageExplorer/MefServices/PluginManager.cs
@@ -20,7 +20,17 @@ namespace PackageExplorer
         private const string NuGetDirectoryName = "NuGet";
         private const string PluginsDirectoryName = "PackageExplorerPlugins";
         private const string DeleteMeExtension = ".deleteme";
-        private static string[] FrameworkFolderForAssemblies = new string[] { "lib\\net40", "lib\\net45", "lib\\net451", "lib\\net452", "lib\\net46", "lib\\net461" };
+        private static string[] FrameworkFolderForAssemblies = new string[] {
+            "lib\\net40",
+            "lib\\net45",
+            "lib\\net451",
+            "lib\\net452",
+            "lib\\net46",
+            "lib\\net461",
+            "lib\\net462",
+            "lib\\net47",
+            "lib\\net471",
+        };
 
         // %localappdata%/NuGet/PackageExplorerPlugins
         private static readonly string PluginsDirectory = Path.Combine(
@@ -90,7 +100,7 @@ namespace PackageExplorer
                         {
                             Directory.Delete(targetPath);
                             UIServices.Value.Show(
-                                "Adding plugin failed. The selected package does not have any assembly inside the 'lib\\net40' folder.",
+                                "Adding plugin failed. The selected package does not have any assembly inside the 'lib\\net*' folder.",
                                 MessageLevel.Error);
                         }
                         else

--- a/PackageExplorer/MefServices/PluginManager.cs
+++ b/PackageExplorer/MefServices/PluginManager.cs
@@ -20,7 +20,7 @@ namespace PackageExplorer
         private const string NuGetDirectoryName = "NuGet";
         private const string PluginsDirectoryName = "PackageExplorerPlugins";
         private const string DeleteMeExtension = ".deleteme";
-        private static string[] FrameworkFolderForAssemblies = new string[] { "lib\\net40", "lib\\net45", "lib\\net451", "lib\\net452", "lib\\net46" };
+        private static string[] FrameworkFolderForAssemblies = new string[] { "lib\\net40", "lib\\net45", "lib\\net451", "lib\\net452", "lib\\net46", "lib\\net461" };
 
         // %localappdata%/NuGet/PackageExplorerPlugins
         private static readonly string PluginsDirectory = Path.Combine(


### PR DESCRIPTION
`NuGetPackageExplorer.Types` target framework is `net461`

reference #160 

(I am also updating https://github.com/NuGetPackageExplorer/Extensions.IlSpy to work with the new NPE version)