### PR TITLE
WAP references nuget package dlls from ref instead of lib folder

### DIFF
--- a/PackageExplorer.Package.Nightly/PackageExplorer.Package.Nightly.wapproj
+++ b/PackageExplorer.Package.Nightly/PackageExplorer.Package.Nightly.wapproj
@@ -63,6 +63,7 @@
   <ItemGroup>
     <ProjectReference Include="..\PackageExplorer\NuGetPackageExplorer.csproj" SkipGetTargetFrameworkProperties="true" />
   </ItemGroup>
+  <!-- Hack to get around https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/issues/391 -->
   <Target Name="AppxPackagedFileReplaceRefWithLib" AfterTargets="_GenerateAppxPackageRecipe">
     <ReplaceFileText InputFilename="$(AppxPackageRecipe)" OutputFilename="$(AppxPackageRecipe)" MatchExpression="\\ref\\" ReplacementText="\lib\" />
   </Target>

--- a/PackageExplorer.Package.Nightly/PackageExplorer.Package.Nightly.wapproj
+++ b/PackageExplorer.Package.Nightly/PackageExplorer.Package.Nightly.wapproj
@@ -63,5 +63,28 @@
   <ItemGroup>
     <ProjectReference Include="..\PackageExplorer\NuGetPackageExplorer.csproj" SkipGetTargetFrameworkProperties="true" />
   </ItemGroup>
+  <Target Name="AppxPackagedFileReplaceRefWithLib" AfterTargets="_GenerateAppxPackageRecipe">
+    <ReplaceFileText InputFilename="$(TargetDir)\$(TargetName).build.appxrecipe" OutputFilename="$(TargetDir)\$(TargetName).build.appxrecipe" MatchExpression="\\ref\\" ReplacementText="\lib\" />
+  </Target>
+  <UsingTask TaskName="ReplaceFileText" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+    <ParameterGroup>
+      <InputFilename ParameterType="System.String" Required="true" />
+      <OutputFilename ParameterType="System.String" Required="true" />
+      <MatchExpression ParameterType="System.String" Required="true" />
+      <ReplacementText ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Reference Include="System.Core" />
+      <Using Namespace="System" />
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Text.RegularExpressions" />
+      <Code Type="Fragment" Language="cs"><![CDATA[
+            File.WriteAllText(
+                OutputFilename,
+                Regex.Replace(File.ReadAllText(InputFilename), MatchExpression, ReplacementText)
+                );
+          ]]></Code>
+    </Task>
+  </UsingTask>
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" />
 </Project>

--- a/PackageExplorer.Package.Nightly/PackageExplorer.Package.Nightly.wapproj
+++ b/PackageExplorer.Package.Nightly/PackageExplorer.Package.Nightly.wapproj
@@ -64,7 +64,7 @@
     <ProjectReference Include="..\PackageExplorer\NuGetPackageExplorer.csproj" SkipGetTargetFrameworkProperties="true" />
   </ItemGroup>
   <Target Name="AppxPackagedFileReplaceRefWithLib" AfterTargets="_GenerateAppxPackageRecipe">
-    <ReplaceFileText InputFilename="$(TargetDir)\$(TargetName).build.appxrecipe" OutputFilename="$(TargetDir)\$(TargetName).build.appxrecipe" MatchExpression="\\ref\\" ReplacementText="\lib\" />
+    <ReplaceFileText InputFilename="$(AppxPackageRecipe)" OutputFilename="$(AppxPackageRecipe)" MatchExpression="\\ref\\" ReplacementText="\lib\" />
   </Target>
   <UsingTask TaskName="ReplaceFileText" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
     <ParameterGroup>

--- a/PackageExplorer.Package/PackageExplorer.Package.wapproj
+++ b/PackageExplorer.Package/PackageExplorer.Package.wapproj
@@ -61,5 +61,31 @@
   <ItemGroup>
     <ProjectReference Include="..\PackageExplorer\NuGetPackageExplorer.csproj" SkipGetTargetFrameworkProperties="true" />
   </ItemGroup>
+  <!-- Hack to get around https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/issues/391 -->
+  <Target Name="AppxPackagedFileReplaceRefWithLib" AfterTargets="_GenerateAppxPackageRecipe">
+    <ReplaceFileText InputFilename="$(AppxPackageRecipe)" OutputFilename="$(AppxPackageRecipe)" MatchExpression="\\ref\\" ReplacementText="\lib\" />
+  </Target>
+  <UsingTask TaskName="ReplaceFileText" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+    <ParameterGroup>
+      <InputFilename ParameterType="System.String" Required="true" />
+      <OutputFilename ParameterType="System.String" Required="true" />
+      <MatchExpression ParameterType="System.String" Required="true" />
+      <ReplacementText ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Reference Include="System.Core" />
+      <Using Namespace="System" />
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Text.RegularExpressions" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+            File.WriteAllText(
+                OutputFilename,
+                Regex.Replace(File.ReadAllText(InputFilename), MatchExpression, ReplacementText)
+                );
+          ]]>
+      </Code>
+    </Task>
+  </UsingTask>
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" />
 </Project>

--- a/PackageExplorer/NuGetPackageExplorer.csproj
+++ b/PackageExplorer/NuGetPackageExplorer.csproj
@@ -29,8 +29,8 @@
     <PackageReference Include="AvalonEdit" Version="5.0.4" />
     <PackageReference Include="GrayscaleEffect" Version="1.0.1" />
     <PackageReference Include="Humanizer" Version="2.2.0" />
-    <PackageReference Include="System.Memory" Version="4.5.0-preview1-26216-02" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.0-preview1-26216-02" />
+    <PackageReference Include="System.Memory" Version="4.5.0-preview2-26406-04" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.0-preview2-26406-04" />
     <ProjectReference Include="..\PackageViewModel\PackageViewModel.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
This is a pretty hacky attempt to fix #391

During the WAP build process the `_GenerateAppxPackageRecipe` target creates a xml file called `$(TargetName).build.appxreceipe` which contains all dlls referenced by the `ProjectReference`s.
Because WAP somehow prefers dlls from the `ref` folder instead of the `lib` folder we can just replace the folder names.

Todo:
- [x] apply this fix to `PackageExplorer.Package`