### PR TITLE
PackageDetailActionsControl: Add default ctor

### DIFF
--- a/PackageExplorer/PackageChooser/PackageDetailActionsControl.xaml
+++ b/PackageExplorer/PackageChooser/PackageDetailActionsControl.xaml
@@ -65,8 +65,7 @@
             </ListView.ItemContainerStyle>
 
             <ListView.View>
-                <GridView AllowsColumnReorder="False" x:Name="PackageGridView" 
-                          ColumnHeaderContainerStyle="{StaticResource PackageVersionsHeaderStyle}">
+                <GridView AllowsColumnReorder="False" x:Name="PackageGridView">
 
                     <GridViewColumn Width="80" Header="Version">
                         <GridViewColumn.HeaderContainerStyle>

--- a/PackageExplorer/PackageChooser/PackageDetailActionsControl.xaml.cs
+++ b/PackageExplorer/PackageChooser/PackageDetailActionsControl.xaml.cs
@@ -6,10 +6,15 @@ using PackageExplorerViewModel;
 namespace PackageExplorer
 {
     /// <summary>
-    /// Interaction logic for PackageRowDetails.xaml
+    /// Interaction logic for PackageDetailActionsControl.xaml
     /// </summary>
     public partial class PackageDetailActionsControl : UserControl
     {
+        public PackageDetailActionsControl()
+        {
+            InitializeComponent();
+        }
+
         private void PackageGrid_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             var viewModel = (PackageInfoViewModel) DataContext;


### PR DESCRIPTION
The non-existing PackageVersionsHeaderStyle is also removed from the GridView.

This PR addresses the items related to PackageDetailActionsControl changes in d73ad368de20f0213a3fe77315d0a6d927f989ad.

ref: #398