### PR TITLE
Package Chooser: Store UI strings in resources.resx

### DIFF
--- a/PackageExplorer/App.xaml
+++ b/PackageExplorer/App.xaml
@@ -117,10 +117,10 @@
 
             <!-- used on the package chooser dialog -->
             <Style x:Key="ShowAllVersionsRunStyle" TargetType="{x:Type Run}">
-                <Setter Property="Text" Value="show all versions" />
+                <Setter Property="Text" Value="{x:Static self:Resources.PackageChooser_ActionShowAllVersions}" />
                 <Style.Triggers>
                     <DataTrigger Binding="{Binding ShowingAllVersions}" Value="True">
-                        <Setter Property="Text" Value="hide all versions" />
+                        <Setter Property="Text" Value="{x:Static self:Resources.PackageChooser_ActionHideAllVersions}" />
                     </DataTrigger>
                 </Style.Triggers>
             </Style>

--- a/PackageExplorer/PackageChooser/PackageChooserDialog.xaml
+++ b/PackageExplorer/PackageChooser/PackageChooserDialog.xaml
@@ -8,7 +8,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d" 
     x:Class="PackageExplorer.PackageChooserDialog"
-    Title="Select Package" 
+    Title="{x:Static self:Resources.PackageChooser_WindowTitle}" 
     ShowInTaskbar="False"
     WindowStartupLocation="CenterOwner"
     Tag="{Binding LoadedCommand}"
@@ -52,9 +52,9 @@
 
         <!-- Search Box -->
         <Grid Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2">
-            <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,10,0,10">
+            <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,10,0,10">
                 <TextBox x:Name="SearchBox" 
-                         ToolTipService.ToolTip="Search for package" 
+                         ToolTipService.ToolTip="{x:Static self:Resources.PackageChooser_SearchBoxTooltip}" 
                          Width="250"
                          HorizontalAlignment="Left" 
                          Padding="5,5,40,5" 
@@ -65,11 +65,11 @@
                          VerticalAlignment="Center"/>
 
                 <!-- Search Button -->
-                <self:GrayscaleButton x:Name="SearchButton" Margin="-60,0,0,0" ToolTip="Search" VerticalAlignment="Center" Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" Command="{Binding SearchCommand}" CommandParameter="{Binding Text, ElementName=SearchBox}">
+                <self:GrayscaleButton x:Name="SearchButton" Margin="-60,0,0,0" ToolTip="{x:Static self:Resources.PackageChooser_SearchButtonTooltip}" VerticalAlignment="Center" Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" Command="{Binding SearchCommand}" CommandParameter="{Binding Text, ElementName=SearchBox}">
                     <self:GrayscaleImage Source="../Images/search.png" />
                 </self:GrayscaleButton>
                 <!-- Clear search button -->
-                <self:GrayscaleButton x:Name="ClearSearchButton" Margin="-20,0,0,0" ToolTip="Clear search" VerticalAlignment="Center" Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" Command="{Binding ClearSearchCommand}">
+                <self:GrayscaleButton x:Name="ClearSearchButton" Margin="-20,0,0,0" ToolTip="{x:Static self:Resources.PackageChooser_ClearSearchButtonTooltip}" VerticalAlignment="Center" Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" Command="{Binding ClearSearchCommand}">
                     <self:GrayscaleImage Source="../Images/clear.png" Stretch="None" />
                 </self:GrayscaleButton>
 
@@ -77,10 +77,10 @@
                 <CheckBox Margin="10,0,0,0" VerticalAlignment="Center" 
                           IsEnabled="{Binding IsEditable}" 
                           IsChecked="{Binding ShowPrereleasePackages}" 
-                          Content="Show pre-release packages" />
+                          Content="{x:Static self:Resources.PackageChooser_ShowPreReleasePackages}" />
             </StackPanel>
 
-            <TextBlock IsHitTestVisible="False" Text="Search (Ctrl+E)" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="10,0,0,0" Foreground="DarkGray">
+            <TextBlock IsHitTestVisible="False" Text="{x:Static self:Resources.PackageChooser_SearchBoxWatermark}" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="10,0,0,0" Foreground="DarkGray">
                 <TextBlock.Style>
                     <Style TargetType="{x:Type TextBlock}">
                         <Setter Property="Visibility" Value="Collapsed"/>
@@ -96,7 +96,7 @@
 
         <!-- Package Source -->
         <DockPanel Margin="0,10,0,10" LastChildFill="True" Grid.Column="1" Grid.Row="1" VerticalAlignment="Center">
-            <Label DockPanel.Dock="Left" Content="_Package source:" Target="{Binding ElementName=PackageSourceBox}" VerticalAlignment="Center" />
+            <Label DockPanel.Dock="Left" Content="{x:Static self:Resources.PackageChooser_PackageSource}" Target="{Binding ElementName=PackageSourceBox}" VerticalAlignment="Center" />
 
             <ComboBox x:Name="PackageSourceBox" ItemsSource="{Binding PackageSources}" IsReadOnly="False" IsEditable="True" 
                       PreviewKeyDown="PackageSourceBox_PreviewKeyDown"

--- a/PackageExplorer/PackageChooser/PackageDetailActionsControl.xaml
+++ b/PackageExplorer/PackageChooser/PackageDetailActionsControl.xaml
@@ -65,8 +65,7 @@
             </ListView.ItemContainerStyle>
 
             <ListView.View>
-                <GridView AllowsColumnReorder="False" x:Name="PackageGridView" 
-                          ColumnHeaderContainerStyle="{StaticResource PackageVersionsHeaderStyle}">
+                <GridView AllowsColumnReorder="False" x:Name="PackageGridView">
 
                     <GridViewColumn Width="80" Header="Version">
                         <GridViewColumn.HeaderContainerStyle>

--- a/PackageExplorer/PackageChooser/PackageDetailActionsControl.xaml
+++ b/PackageExplorer/PackageChooser/PackageDetailActionsControl.xaml
@@ -1,4 +1,5 @@
 ﻿<UserControl x:Class="PackageExplorer.PackageDetailActionsControl"
+             xmlns:self="clr-namespace:PackageExplorer"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -16,13 +17,13 @@
         <StackPanel Orientation="Horizontal" Grid.Row="0" Margin="0,0,0,0" HorizontalAlignment="Left">
             <TextBlock Margin="5,0">
                 <Hyperlink Command="{Binding OpenCommand}">
-                    <Run Text="open" />
+                    <Run Text="{x:Static self:Resources.PackageChooser_ActionOpen}" />
                 </Hyperlink>
             </TextBlock>
 
             <TextBlock Margin="5,0" Style="{StaticResource DownloadButtonStyle}">
                 <Hyperlink Command="{Binding DownloadCommand}">
-                    <Run Text="download"/>
+                    <Run Text="{x:Static self:Resources.PackageChooser_ActionDownload}"/>
                 </Hyperlink>
             </TextBlock>
 
@@ -67,7 +68,7 @@
             <ListView.View>
                 <GridView AllowsColumnReorder="False" x:Name="PackageGridView">
 
-                    <GridViewColumn Width="80" Header="Version">
+                    <GridViewColumn Width="80" Header="{x:Static self:Resources.PackageChooser_ColumnHeaderVersion}">
                         <GridViewColumn.HeaderContainerStyle>
                             <Style TargetType="{x:Type GridViewColumnHeader}">
                                 <Setter Property="HorizontalContentAlignment" Value="Right"/>
@@ -81,7 +82,7 @@
                         </GridViewColumn.CellTemplate>
                     </GridViewColumn>
 
-                    <GridViewColumn Header="Downloads">
+                    <GridViewColumn Header="{x:Static self:Resources.PackageChooser_ColumnHeaderDownloads}">
                         <GridViewColumn.HeaderContainerStyle>
                             <Style TargetType="{x:Type GridViewColumnHeader}">
                                 <Setter Property="HorizontalContentAlignment" Value="Right"/>
@@ -95,7 +96,7 @@
                         </GridViewColumn.CellTemplate>
                     </GridViewColumn>
 
-                    <GridViewColumn Header="Published">
+                    <GridViewColumn Header="{x:Static self:Resources.PackageChooser_ColumnHeaderPublished}">
                         <GridViewColumn.HeaderContainerStyle>
                             <Style TargetType="{x:Type GridViewColumnHeader}">
                                 <Setter Property="HorizontalContentAlignment" Value="Left"/>

--- a/PackageExplorer/PackageChooser/PackageDetailActionsControl.xaml.cs
+++ b/PackageExplorer/PackageChooser/PackageDetailActionsControl.xaml.cs
@@ -6,10 +6,15 @@ using PackageExplorerViewModel;
 namespace PackageExplorer
 {
     /// <summary>
-    /// Interaction logic for PackageRowDetails.xaml
+    /// Interaction logic for PackageDetailActionsControl.xaml
     /// </summary>
     public partial class PackageDetailActionsControl : UserControl
     {
+        public PackageDetailActionsControl()
+        {
+            InitializeComponent();
+        }
+
         private void PackageGrid_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             var viewModel = (PackageInfoViewModel) DataContext;

--- a/PackageExplorer/PackageChooser/PackageDetailControl.xaml
+++ b/PackageExplorer/PackageChooser/PackageDetailControl.xaml
@@ -21,7 +21,7 @@
                 <self:PackageDetailActionsControl HorizontalAlignment="Stretch"/>
 
                 <!-- Description -->
-                <Label FontWeight="Bold" HorizontalAlignment="Left">Description</Label>
+                <Label FontWeight="Bold" HorizontalAlignment="Left" Content="{x:Static self:Resources.PackageChooser_DetailDescription}" />
                 <TextBlock Text="{Binding LatestPackageInfo.Description}" TextWrapping="Wrap" Margin="5,0,0,10" HorizontalAlignment="Left"/>
 
                 <Grid>
@@ -52,15 +52,15 @@
                     </Grid.ColumnDefinitions>
 
                     <!-- Version -->
-                    <Label Grid.Row="0" Grid.Column="0">Version:</Label>
+                    <Label Grid.Row="0" Grid.Column="0" Content="{x:Static self:Resources.PackageChooser_DetailVersion}" />
                     <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding LatestPackageInfo.Version}" />
 
                     <!-- Authors -->
-                    <Label Grid.Row="1" Grid.Column="0">Author(s):</Label>
+                    <Label Grid.Row="1" Grid.Column="0" Content="{x:Static self:Resources.PackageChooser_DetailAuthors}" />
                     <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding LatestPackageInfo.Authors}" />
 
                     <!-- License URL -->
-                    <Label Grid.Row="2" Grid.Column="0">License:</Label>
+                    <Label Grid.Row="2" Grid.Column="0" Content="{x:Static self:Resources.PackageChooser_DetailLicense}" />
                     <TextBlock Grid.Row="2" Grid.Column="1">
                         <Hyperlink NavigateUri="{Binding LatestPackageInfo.LicenseUrl}" RequestNavigate="Hyperlink_OnRequestNavigate">
                             <Run Text="{Binding LatestPackageInfo.LicenseUrl}"/>
@@ -68,27 +68,27 @@
                     </TextBlock>
 
                     <!-- Published Date -->
-                    <Label Grid.Row="3" Grid.Column="0">Date published:</Label>
+                    <Label Grid.Row="3" Grid.Column="0" Content="{x:Static self:Resources.PackageChooser_DetailDatePublished}" />
                     <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding LatestPackageInfo.Published}" />
 
-                    <!-- Project URL -->
-                    <Label Grid.Row="4" Grid.Column="0">Project URL:</Label>
+                    <!-- Project URL --> 
+                    <Label Grid.Row="4" Grid.Column="0" Content="{x:Static self:Resources.PackageChooser_DetailProjectUrl}" />
                     <TextBlock Grid.Row="4" Grid.Column="1">
                         <Hyperlink NavigateUri="{Binding LatestPackageInfo.ProjectUrl}" RequestNavigate="Hyperlink_OnRequestNavigate">
                             <Run Text="{Binding LatestPackageInfo.ProjectUrl}"/>
                         </Hyperlink>
                     </TextBlock>
 
-                    <!-- Report Abuse URL -->
-                    <Label Grid.Row="5" Grid.Column="0">Report Abuse:</Label>
+                     <!-- Report Abuse URL -->
+                    <Label Grid.Row="5" Grid.Column="0" Content="{x:Static self:Resources.PackageChooser_DetailReportAbuse}" />
                     <TextBlock Grid.Row="5" Grid.Column="1">
                         <Hyperlink NavigateUri="{Binding LatestPackageInfo.ReportAbuseUrl}" RequestNavigate="Hyperlink_OnRequestNavigate">
                             <Run Text="{Binding LatestPackageInfo.ReportAbuseUrl}" />
                         </Hyperlink>
                     </TextBlock>
 
-                    <!-- Tags -->
-                    <Label Grid.Row="6" Grid.Column="0">Tags:</Label>
+                     <!-- Tags --> 
+                    <Label Grid.Row="6" Grid.Column="0" Content="{x:Static self:Resources.PackageChooser_DetailTags}" />
                     <TextBlock Grid.Row="6" Grid.Column="1" Text="{Binding LatestPackageInfo.Tags}" />
                 </Grid>
             </StackPanel>

--- a/PackageExplorer/Resources.Designer.cs
+++ b/PackageExplorer/Resources.Designer.cs
@@ -396,6 +396,204 @@ namespace PackageExplorer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to download.
+        /// </summary>
+        public static string PackageChooser_ActionDownload {
+            get {
+                return ResourceManager.GetString("PackageChooser_ActionDownload", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to hide all versions.
+        /// </summary>
+        public static string PackageChooser_ActionHideAllVersions {
+            get {
+                return ResourceManager.GetString("PackageChooser_ActionHideAllVersions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to open.
+        /// </summary>
+        public static string PackageChooser_ActionOpen {
+            get {
+                return ResourceManager.GetString("PackageChooser_ActionOpen", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to show all versions.
+        /// </summary>
+        public static string PackageChooser_ActionShowAllVersions {
+            get {
+                return ResourceManager.GetString("PackageChooser_ActionShowAllVersions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Clear search.
+        /// </summary>
+        public static string PackageChooser_ClearSearchButtonTooltip {
+            get {
+                return ResourceManager.GetString("PackageChooser_ClearSearchButtonTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Downloads.
+        /// </summary>
+        public static string PackageChooser_ColumnHeaderDownloads {
+            get {
+                return ResourceManager.GetString("PackageChooser_ColumnHeaderDownloads", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Published.
+        /// </summary>
+        public static string PackageChooser_ColumnHeaderPublished {
+            get {
+                return ResourceManager.GetString("PackageChooser_ColumnHeaderPublished", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Version.
+        /// </summary>
+        public static string PackageChooser_ColumnHeaderVersion {
+            get {
+                return ResourceManager.GetString("PackageChooser_ColumnHeaderVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Author(s):.
+        /// </summary>
+        public static string PackageChooser_DetailAuthors {
+            get {
+                return ResourceManager.GetString("PackageChooser_DetailAuthors", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Date published:.
+        /// </summary>
+        public static string PackageChooser_DetailDatePublished {
+            get {
+                return ResourceManager.GetString("PackageChooser_DetailDatePublished", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Description.
+        /// </summary>
+        public static string PackageChooser_DetailDescription {
+            get {
+                return ResourceManager.GetString("PackageChooser_DetailDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to License:.
+        /// </summary>
+        public static string PackageChooser_DetailLicense {
+            get {
+                return ResourceManager.GetString("PackageChooser_DetailLicense", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Project URL:.
+        /// </summary>
+        public static string PackageChooser_DetailProjectUrl {
+            get {
+                return ResourceManager.GetString("PackageChooser_DetailProjectUrl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Report Abuse:.
+        /// </summary>
+        public static string PackageChooser_DetailReportAbuse {
+            get {
+                return ResourceManager.GetString("PackageChooser_DetailReportAbuse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tags:.
+        /// </summary>
+        public static string PackageChooser_DetailTags {
+            get {
+                return ResourceManager.GetString("PackageChooser_DetailTags", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Version:.
+        /// </summary>
+        public static string PackageChooser_DetailVersion {
+            get {
+                return ResourceManager.GetString("PackageChooser_DetailVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to _Package source:.
+        /// </summary>
+        public static string PackageChooser_PackageSource {
+            get {
+                return ResourceManager.GetString("PackageChooser_PackageSource", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Search for package.
+        /// </summary>
+        public static string PackageChooser_SearchBoxTooltip {
+            get {
+                return ResourceManager.GetString("PackageChooser_SearchBoxTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Search (Ctrl+E).
+        /// </summary>
+        public static string PackageChooser_SearchBoxWatermark {
+            get {
+                return ResourceManager.GetString("PackageChooser_SearchBoxWatermark", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Search.
+        /// </summary>
+        public static string PackageChooser_SearchButtonTooltip {
+            get {
+                return ResourceManager.GetString("PackageChooser_SearchButtonTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Show pre-release packages.
+        /// </summary>
+        public static string PackageChooser_ShowPreReleasePackages {
+            get {
+                return ResourceManager.GetString("PackageChooser_ShowPreReleasePackages", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select Package.
+        /// </summary>
+        public static string PackageChooser_WindowTitle {
+            get {
+                return ResourceManager.GetString("PackageChooser_WindowTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to download package correctly. The contents of the package could not be verified..
         /// </summary>
         public static string PackageContentsVerifyError {

--- a/PackageExplorer/Resources.resx
+++ b/PackageExplorer/Resources.resx
@@ -230,6 +230,72 @@ Do you want to add '{0}' to the list of package publish sources?</value>
   <data name="NoNetworkConnection" xml:space="preserve">
     <value>Network connection is not detected.</value>
   </data>
+  <data name="PackageChooser_ActionDownload" xml:space="preserve">
+    <value>download</value>
+  </data>
+  <data name="PackageChooser_ActionHideAllVersions" xml:space="preserve">
+    <value>hide all versions</value>
+  </data>
+  <data name="PackageChooser_ActionOpen" xml:space="preserve">
+    <value>open</value>
+  </data>
+  <data name="PackageChooser_ActionShowAllVersions" xml:space="preserve">
+    <value>show all versions</value>
+  </data>
+  <data name="PackageChooser_ClearSearchButtonTooltip" xml:space="preserve">
+    <value>Clear search</value>
+  </data>
+  <data name="PackageChooser_ColumnHeaderDownloads" xml:space="preserve">
+    <value>Downloads</value>
+  </data>
+  <data name="PackageChooser_ColumnHeaderPublished" xml:space="preserve">
+    <value>Published</value>
+  </data>
+  <data name="PackageChooser_ColumnHeaderVersion" xml:space="preserve">
+    <value>Version</value>
+  </data>
+  <data name="PackageChooser_DetailAuthors" xml:space="preserve">
+    <value>Author(s):</value>
+  </data>
+  <data name="PackageChooser_DetailDatePublished" xml:space="preserve">
+    <value>Date published:</value>
+  </data>
+  <data name="PackageChooser_DetailDescription" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="PackageChooser_DetailLicense" xml:space="preserve">
+    <value>License:</value>
+  </data>
+  <data name="PackageChooser_DetailProjectUrl" xml:space="preserve">
+    <value>Project URL:</value>
+  </data>
+  <data name="PackageChooser_DetailReportAbuse" xml:space="preserve">
+    <value>Report Abuse:</value>
+  </data>
+  <data name="PackageChooser_DetailTags" xml:space="preserve">
+    <value>Tags:</value>
+  </data>
+  <data name="PackageChooser_DetailVersion" xml:space="preserve">
+    <value>Version:</value>
+  </data>
+  <data name="PackageChooser_PackageSource" xml:space="preserve">
+    <value>_Package source:</value>
+  </data>
+  <data name="PackageChooser_SearchBoxTooltip" xml:space="preserve">
+    <value>Search for package</value>
+  </data>
+  <data name="PackageChooser_SearchBoxWatermark" xml:space="preserve">
+    <value>Search (Ctrl+E)</value>
+  </data>
+  <data name="PackageChooser_SearchButtonTooltip" xml:space="preserve">
+    <value>Search</value>
+  </data>
+  <data name="PackageChooser_ShowPreReleasePackages" xml:space="preserve">
+    <value>Show pre-release packages</value>
+  </data>
+  <data name="PackageChooser_WindowTitle" xml:space="preserve">
+    <value>Select Package</value>
+  </data>
   <data name="PackageContentsVerifyError" xml:space="preserve">
     <value>Failed to download package correctly. The contents of the package could not be verified.</value>
   </data>


### PR DESCRIPTION
I branched on the `features/package-chooser-pkg...` branch as I needed the change in that branch here. Please let me know otherwise.

This PR address the request to store the labels in resources.resx for Package Chooser Diaglog per @onovotny #398.