### PR TITLE
Pkg Chooser: Improve package selection

### DIFF
--- a/PackageExplorer/PackageChooser/PackageChooserDialog.xaml
+++ b/PackageExplorer/PackageChooser/PackageChooserDialog.xaml
@@ -123,11 +123,10 @@
                  ItemsSource="{Binding Packages}"
                  ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                  ScrollViewer.CanContentScroll="False"
-                 SelectedItem="{Binding SelectedPackageViewModel}">
+                 SelectedValue="{Binding SelectedPackageViewModel}">
             <ListBox.ItemContainerStyle>
                 <Style TargetType="{x:Type ListBoxItem}">
                     <EventSetter Event="MouseDoubleClick" Handler="OnPackageDoubleClick" />
-                    <EventSetter Event="PreviewMouseDown" Handler="PackageListBoxItem_OnPreviewMouseDown" />
                     <Setter Property="Padding" Value="10,10,10,10"/>
                     <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
                 </Style>
@@ -185,7 +184,7 @@
 
         <!-- Package Detail -->
         <Border Grid.Row="3" Grid.Column="1" BorderBrush="LightGray" BorderThickness="1" Margin="0,0,0,10">
-            <self:PackageDetailControl x:Name="PackageDetailControl" HorizontalAlignment="Stretch" />
+            <self:PackageDetailControl x:Name="PackageDetailControl" HorizontalAlignment="Stretch" DataContext="{Binding Path=SelectedPackageViewModel}" />
         </Border>
 
         <!-- Progress Panel -->

--- a/PackageExplorer/PackageChooser/PackageChooserDialog.xaml
+++ b/PackageExplorer/PackageChooser/PackageChooserDialog.xaml
@@ -184,7 +184,9 @@
 
         <!-- Package Detail -->
         <Border Grid.Row="3" Grid.Column="1" BorderBrush="LightGray" BorderThickness="1" Margin="0,0,0,10">
-            <self:PackageDetailControl x:Name="PackageDetailControl" HorizontalAlignment="Stretch" DataContext="{Binding Path=SelectedPackageViewModel}" />
+            <self:PackageDetailControl x:Name="PackageDetailControl" HorizontalAlignment="Stretch" 
+                                       DataContext="{Binding Path=SelectedPackageViewModel}" 
+                                       Visibility="{Binding Path=., Converter={StaticResource NullToVisibilityConverter}}" />
         </Border>
 
         <!-- Progress Panel -->

--- a/PackageExplorer/PackageChooser/PackageChooserDialog.xaml.cs
+++ b/PackageExplorer/PackageChooser/PackageChooserDialog.xaml.cs
@@ -47,8 +47,7 @@ namespace PackageExplorer
         private void CancelPendingRequestAndCloseDialog()
         {
             CancelPendingRequest();
-            ListBoxPackages.SelectedItem = null; //TODO
-            PackageDetailControl.DataContext = null;
+            _viewModel.SelectedPackageViewModel = null;
             Hide();
         }
 
@@ -160,7 +159,6 @@ namespace PackageExplorer
                 if (!string.IsNullOrEmpty(source))
                 {
                     _viewModel.ChangePackageSourceCommand.Execute(source);
-                    PackageDetailControl.Visibility = Visibility.Collapsed;
                     e.Handled = true;
                 }
             }
@@ -201,13 +199,6 @@ namespace PackageExplorer
             }
         }
 
-        private void PackageListBoxItem_OnPreviewMouseDown(object sender, RoutedEventArgs e)
-        {
-            var listBoxItem = (ListBoxItem)sender;
-            var packageInfoViewModel = (PackageInfoViewModel)listBoxItem.DataContext;
-            PackageDetailControl.DataContext = packageInfoViewModel;
-        }
-
         private void PackageSourceBox_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (e.AddedItems == null || e.AddedItems.Count == 0)
@@ -220,7 +211,6 @@ namespace PackageExplorer
             if (!string.IsNullOrWhiteSpace(sourceUrl))
             {
                 _viewModel.ChangePackageSourceCommand.Execute(sourceUrl);
-                PackageDetailControl.Visibility = Visibility.Collapsed;
             }
 
             e.Handled = true;

--- a/PackageExplorer/PackageChooser/PackageChooserDialog.xaml.cs
+++ b/PackageExplorer/PackageChooser/PackageChooserDialog.xaml.cs
@@ -82,19 +82,16 @@ namespace PackageExplorer
 
         private async void Window_Loaded(object sender, RoutedEventArgs e)
         {
-            if (_viewModel.AutoLoadPackages)
+            if (string.IsNullOrEmpty(_pendingSearch))
             {
-                if (string.IsNullOrEmpty(_pendingSearch))
-                {
-                    await Dispatcher.BeginInvoke(new Action(LoadPackages), DispatcherPriority.Background);
-                }
-                else
-                {
-                    await Dispatcher.BeginInvoke(
-                        new Action<string>(InvokeSearch),
-                        DispatcherPriority.Background,
-                        _pendingSearch);
-                }
+                await Dispatcher.BeginInvoke(new Action(LoadPackages), DispatcherPriority.Background);
+            }
+            else
+            {
+                await Dispatcher.BeginInvoke(
+                    new Action<string>(InvokeSearch),
+                    DispatcherPriority.Background,
+                    _pendingSearch);
             }
         }
 

--- a/PackageExplorer/PackageChooser/PackageDetailActionsControl.xaml
+++ b/PackageExplorer/PackageChooser/PackageDetailActionsControl.xaml
@@ -41,7 +41,7 @@
             Margin="4,4,4,4"
             BorderBrush="LightGray"
             ItemsSource="{Binding AllPackages, Mode=OneWay}" 
-            SelectedItem="{Binding SelectedPackage, Mode=OneWay}"
+            SelectedValue="{Binding SelectedPackage, Mode=OneWay}"
             SelectionChanged="PackageGrid_SelectionChanged"
             SelectionMode="Single"
             HorizontalAlignment="Stretch"

--- a/PackageExplorer/PackageChooser/PackageDetailControl.xaml.cs
+++ b/PackageExplorer/PackageChooser/PackageDetailControl.xaml.cs
@@ -1,8 +1,6 @@
 ﻿using System.Diagnostics;
-using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Navigation;
-using PackageExplorerViewModel;
 
 namespace PackageExplorer
 {
@@ -14,12 +12,6 @@ namespace PackageExplorer
         public PackageDetailControl()
         {
             InitializeComponent();
-            DataContextChanged += OnDataContextChanged;
-        }
-
-        private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
-        {
-            Visibility = DataContext is PackageInfoViewModel ? Visibility.Visible : Visibility.Collapsed;
         }
 
         private void Hyperlink_OnRequestNavigate(object sender, RequestNavigateEventArgs e)

--- a/PackageExplorer/Properties/Settings.settings
+++ b/PackageExplorer/Properties/Settings.settings
@@ -59,9 +59,6 @@
     <Setting Name="IsFirstTimeAfterMigrate" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
-    <Setting Name="AutoLoadPackages" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">True</Value>
-    </Setting>
     <Setting Name="SigningCertificate" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>

--- a/PackageExplorer/app.config
+++ b/PackageExplorer/app.config
@@ -2,10 +2,70 @@
 <configuration>
     <configSections>
         <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+            <section name="PackageExplorer.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
             <section name="NuGetPackageExplorer.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
         </sectionGroup>
     </configSections>
     <userSettings>
+        <PackageExplorer.Properties.Settings>
+            <setting name="FontSize" serializeAs="String">
+                <value>12</value>
+            </setting>
+            <setting name="ContentViewerHeight" serializeAs="String">
+                <value>400</value>
+            </setting>
+            <setting name="PackageSource" serializeAs="String">
+                <value>https://api.nuget.org/v3/index.json</value>
+            </setting>
+            <setting name="WindowPlacement" serializeAs="String">
+                <value />
+            </setting>
+            <setting name="PublishPrivateKey" serializeAs="String">
+                <value />
+            </setting>
+            <setting name="PublishPackageLocation" serializeAs="String">
+                <value>https://nuget.org</value>
+            </setting>
+            <setting name="PackageChooserDialogWidth" serializeAs="String">
+                <value>630</value>
+            </setting>
+            <setting name="PackageChooserDialogHeight" serializeAs="String">
+                <value>450</value>
+            </setting>
+            <setting name="IsFirstTime" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="PackageContentHeight" serializeAs="String">
+                <value>400</value>
+            </setting>
+            <setting name="ShowTaskShortcuts" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="WordWrap" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="ShowLineNumbers" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="PublishAsUnlisted" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="ShowPrereleasePackages" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="IsFirstTimeAfterMigrate" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="SigningCertificate" serializeAs="String">
+                <value />
+            </setting>
+            <setting name="TimestampServer" serializeAs="String">
+                <value />
+            </setting>
+            <setting name="SigningHashAlgorithmName" serializeAs="String">
+                <value />
+            </setting>
+        </PackageExplorer.Properties.Settings>
         <NuGetPackageExplorer.Properties.Settings>
             <setting name="FontSize" serializeAs="String">
                 <value>12</value>

--- a/PackageViewModel/PackageChooser/PackageChooserViewModel.cs
+++ b/PackageViewModel/PackageChooser/PackageChooserViewModel.cs
@@ -317,6 +317,7 @@ namespace PackageExplorerViewModel
                 ClearPackages(isErrorCase: true);
             }
 
+            AutoSelectFirstAvailablePackage();
             RestoreUI();
         }
 
@@ -399,6 +400,11 @@ namespace PackageExplorerViewModel
         {
             BeginPackage = beginPackage;
             EndPackage = endPackage;
+        }
+
+        private void AutoSelectFirstAvailablePackage()
+        {
+            SelectedPackageViewModel = Packages?.FirstOrDefault();
         }
 
         private void ClearPackages(bool isErrorCase)

--- a/PackageViewModel/PackageChooser/PackageChooserViewModel.cs
+++ b/PackageViewModel/PackageChooser/PackageChooserViewModel.cs
@@ -15,52 +15,35 @@ namespace PackageExplorerViewModel
 {
     public sealed class PackageChooserViewModel : ViewModelBase, IDisposable
     {
-        private const int ShowLatestVersionPageSize = 15;
-        private const int PageBuffer = 30;
-        private readonly string _fixedPackageSource;
-        private int _beginPackage;
-        private CancellationTokenSource _currentCancellationTokenSource;
+        private const int PackageListPageSize = 15;
+        
         private IQueryContext<IPackageSearchMetadata> _currentQuery;
         private string _currentSearch;
-        private string _currentTypingSearch;
-        private int _endPackage;
-        private bool _hasError;
-        private bool _isEditable = true;
-        private SourceRepository _packageRepository;
         private FeedType _feedType;
         private MruPackageSourceManager _packageSourceManager;
-        private bool _showPrereleasePackages;
-        private bool _autoLoadPackages;
-        private string _statusContent;
-        private PackageInfoViewModel _selectedPackageViewModel;
+        private readonly string _defaultPackageSourceUrl;
 
-        public PackageChooserViewModel(
-            MruPackageSourceManager packageSourceManager,
-            bool showPrereleasePackages,
-            bool autoLoadPackages,
-            string fixedPackageSource)
+        public PackageChooserViewModel(MruPackageSourceManager packageSourceManager,
+                                       bool showPrereleasePackages,
+                                       string defaultPackageSourceUrl)
         {
             _showPrereleasePackages = showPrereleasePackages;
-            _fixedPackageSource = fixedPackageSource;
-            _autoLoadPackages = autoLoadPackages;
+            _defaultPackageSourceUrl = defaultPackageSourceUrl;
             Packages = new ObservableCollection<PackageInfoViewModel>();
+
             SearchCommand = new RelayCommand<string>(Search, CanSearch);
             ClearSearchCommand = new RelayCommand(ClearSearch, CanClearSearch);
             NavigationCommand = new RelayCommand<string>(NavigationCommandExecute, NavigationCommandCanExecute);
             LoadedCommand = new RelayCommand(async () => await LoadPackages());
             ChangePackageSourceCommand = new RelayCommand<string>(ChangePackageSource);
             CancelCommand = new RelayCommand(CancelCommandExecute, CanCancelCommandExecute);
-            _packageSourceManager = packageSourceManager ?? throw new ArgumentNullException("packageSourceManager");
+
+            _packageSourceManager = packageSourceManager ?? throw new ArgumentNullException(nameof(packageSourceManager));
         }
 
-        public SourceRepository ActiveRepository
-        {
-            get
-            {
-                return _packageRepository;
-            }
-        }
+        #region Bound Properties
 
+        private string _currentTypingSearch;
         public string CurrentTypingSearch
         {
             get { return _currentTypingSearch; }
@@ -69,11 +52,70 @@ namespace PackageExplorerViewModel
                 if (_currentTypingSearch != value)
                 {
                     _currentTypingSearch = value;
-                    OnPropertyChanged("CurrentTypingSearch");
+                    OnPropertyChanged();
                 }
             }
         }
 
+        private bool _showPrereleasePackages;
+        public bool ShowPrereleasePackages
+        {
+            get { return _showPrereleasePackages; }
+            set
+            {
+                if (_showPrereleasePackages != value)
+                {
+                    _showPrereleasePackages = value;
+                    OnPropertyChanged();
+
+                    OnShowPrereleasePackagesChange();
+                }
+            }
+        }
+        
+        public string PackageSource
+        {
+            get { return _defaultPackageSourceUrl ?? _packageSourceManager.ActivePackageSource; }
+            private set
+            {
+                if (_defaultPackageSourceUrl != null)
+                {
+                    throw new InvalidOperationException(
+                        "Cannot set active package source when fixed package source is used.");
+                }
+                _packageSourceManager.ActivePackageSource = value;
+                OnPropertyChanged();
+            }
+        }
+        
+        public bool AllowsChangingPackageSource
+        {
+            get { return _defaultPackageSourceUrl == null; }
+        }
+
+        public ObservableCollection<string> PackageSources
+        {
+            get { return _packageSourceManager.PackageSources; }
+        }
+
+        private bool _isEditable = true;
+        public bool IsEditable
+        {
+            get { return _isEditable; }
+            set
+            {
+                if (_isEditable != value)
+                {
+                    _isEditable = value;
+                    OnPropertyChanged();
+                    NavigationCommand.RaiseCanExecuteChanged();
+                }
+            }
+        }
+        
+        public ObservableCollection<PackageInfoViewModel> Packages { get; private set; }
+        
+        private PackageInfoViewModel _selectedPackageViewModel;
         public PackageInfoViewModel SelectedPackageViewModel
         {
             get { return _selectedPackageViewModel; }
@@ -91,6 +133,66 @@ namespace PackageExplorerViewModel
                 }
             }
         }
+        
+        private int _beginPackage;
+        public int BeginPackage
+        {
+            get { return _beginPackage; }
+            private set
+            {
+                if (_beginPackage != value)
+                {
+                    _beginPackage = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        private int _endPackage;
+        public int EndPackage
+        {
+            get { return _endPackage; }
+            private set
+            {
+                if (_endPackage != value)
+                {
+                    _endPackage = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        private string _statusContent;
+        public string StatusContent
+        {
+            get { return _statusContent; }
+            set
+            {
+                if (_statusContent != value)
+                {
+                    _statusContent = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        private bool _hasError;
+        public bool HasError
+        {
+            get { return _hasError; }
+            set
+            {
+                if (_hasError != value)
+                {
+                    _hasError = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+        
+        #endregion
+
+        public SourceRepository ActiveRepository { get; private set; }
 
         public PackageInfo SelectedPackage
         {
@@ -99,74 +201,8 @@ namespace PackageExplorerViewModel
                 return _selectedPackageViewModel?.EffectiveSelectedPackage;
             }
         }
-
-        public bool IsEditable
-        {
-            get { return _isEditable; }
-            set
-            {
-                if (_isEditable != value)
-                {
-                    _isEditable = value;
-                    OnPropertyChanged("IsEditable");
-                    NavigationCommand.RaiseCanExecuteChanged();
-                }
-            }
-        }
-
-        public bool ShowPrereleasePackages
-        {
-            get { return _showPrereleasePackages; }
-            set
-            {
-                if (_showPrereleasePackages != value)
-                {
-                    _showPrereleasePackages = value;
-                    OnPropertyChanged("ShowPrereleasePackages");
-
-                    OnShowPrereleasePackagesChange();
-                }
-            }
-        }
-
-        public bool AutoLoadPackages
-        {
-            get { return _autoLoadPackages; }
-            set
-            {
-                if (_autoLoadPackages != value)
-                {
-                    _autoLoadPackages = value;
-                    OnPropertyChanged();
-                }
-            }
-        }
-
-        public ObservableCollection<string> PackageSources
-        {
-            get { return _packageSourceManager.PackageSources; }
-        }
-
-        public bool AllowsChangingPackageSource
-        {
-            get { return _fixedPackageSource == null; }
-        }
-
-        public string PackageSource
-        {
-            get { return _fixedPackageSource ?? _packageSourceManager.ActivePackageSource; }
-            private set
-            {
-                if (_fixedPackageSource != null)
-                {
-                    throw new InvalidOperationException(
-                        "Cannot set active package source when fixed package source is used.");
-                }
-                _packageSourceManager.ActivePackageSource = value;
-                OnPropertyChanged("PackageSource");
-            }
-        }
-
+        
+        private CancellationTokenSource _currentCancellationTokenSource;
         private CancellationTokenSource CurrentCancellationTokenSource
         {
             get { return _currentCancellationTokenSource; }
@@ -176,99 +212,70 @@ namespace PackageExplorerViewModel
                 CancelCommand.RaiseCanExecuteChanged();
             }
         }
-
-        public int BeginPackage
-        {
-            get { return _beginPackage; }
-            private set
-            {
-                if (_beginPackage != value)
-                {
-                    _beginPackage = value;
-                    OnPropertyChanged("BeginPackage");
-                }
-            }
-        }
-
-        public int EndPackage
-        {
-            get { return _endPackage; }
-            private set
-            {
-                if (_endPackage != value)
-                {
-                    _endPackage = value;
-                    OnPropertyChanged("EndPackage");
-                }
-            }
-        }
-
-        public string StatusContent
-        {
-            get { return _statusContent; }
-            set
-            {
-                if (_statusContent != value)
-                {
-                    _statusContent = value;
-                    OnPropertyChanged("StatusContent");
-                }
-            }
-        }
-
-        public bool HasError
-        {
-            get { return _hasError; }
-            set
-            {
-                if (_hasError != value)
-                {
-                    _hasError = value;
-                    OnPropertyChanged("HasError");
-                }
-            }
-        }
-
-        public ObservableCollection<PackageInfoViewModel> Packages { get; private set; }
-
+        
+        #region Commands
         public RelayCommand<string> NavigationCommand { get; private set; }
         public ICommand SearchCommand { get; private set; }
         public ICommand ClearSearchCommand { get; private set; }
         public ICommand LoadedCommand { get; private set; }
         public ICommand ChangePackageSourceCommand { get; private set; }
         public RelayCommand CancelCommand { get; private set; }
+        #endregion
 
+        #region EventHandler
         public event EventHandler LoadPackagesCompleted = delegate { };
         public event EventHandler OpenPackageRequested = delegate { };
         public event EventHandler PackageDownloadRequested = delegate { };
+        #endregion
 
-        private async void OnShowPrereleasePackagesChange()
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling"), 
+         System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
+        private async Task LoadPackages()
         {
-            await LoadPackages();
+            IsEditable = false;
+            ClearPackages(isErrorCase: true);
+
+            CurrentCancellationTokenSource = new CancellationTokenSource();
+            var usedTokenSource = CurrentCancellationTokenSource;
+
+            var repository = GetPackageRepository();
+            if (repository == null)
+            {
+                await LoadPage(CurrentCancellationTokenSource.Token);
+                return;
+            }
+
+            _currentQuery = new ShowLatestVersionQueryContext<IPackageSearchMetadata>(repository, _currentSearch, ShowPrereleasePackages, PackageListPageSize);
+            _feedType = await repository.GetFeedType(usedTokenSource.Token);
+
+            await LoadPage(CurrentCancellationTokenSource.Token);
+        }
+
+        private void ClearPackages(bool isErrorCase)
+        {
+            Packages.Clear();
+            if (isErrorCase)
+            {
+                UpdatePageNumber(0, 0);
+            }
         }
 
         private SourceRepository GetPackageRepository()
         {
-            if (_packageRepository == null)
+            if (ActiveRepository == null)
             {
                 _feedType = FeedType.Undefined;
-                _packageRepository = PackageRepositoryFactory.CreateRepository(PackageSource);
+                ActiveRepository = PackageRepositoryFactory.CreateRepository(PackageSource);
             }
 
-            return _packageRepository;
+            return ActiveRepository;
         }
 
-        private void ResetPackageRepository()
-        {
-            _packageRepository = null;
-        }
-
-        internal async Task LoadPage(CancellationToken token)
+        private async Task LoadPage(CancellationToken token)
         {
             Debug.Assert(_currentQuery != null);
 
             IsEditable = false;
-            //ShowMessage(Resources.LoadingMessage, false);
             ClearPackages(isErrorCase: false);
 
             if (token == CancellationToken.None)
@@ -285,7 +292,7 @@ namespace PackageExplorerViewModel
 
                 if (usedTokenSource != CurrentCancellationTokenSource)
                 {
-                    // this mean this request has already been canceled. No need to process this request anymore.
+                    // This request has already been canceled. No need to process this request anymore.
                     return;
                 }
 
@@ -296,7 +303,7 @@ namespace PackageExplorerViewModel
             {
                 if (usedTokenSource != CurrentCancellationTokenSource)
                 {
-                    // this mean this request has already been canceled. No need to process this request anymore.
+                    // This request has already been canceled. No need to process this request anymore.
                     return;
                 }
 
@@ -307,7 +314,7 @@ namespace PackageExplorerViewModel
             {
                 if (usedTokenSource != CurrentCancellationTokenSource)
                 {
-                    // this mean this request has already been canceled. No need to process this request anymore.
+                    // This request has already been canceled. No need to process this request anymore.
                     return;
                 }
 
@@ -320,7 +327,7 @@ namespace PackageExplorerViewModel
             AutoSelectFirstAvailablePackage();
             RestoreUI();
         }
-
+        
         private async Task<IList<IPackageSearchMetadata>> QueryPackages(CancellationToken token)
         {
             var result = await _currentQuery.GetItemsForCurrentPage(token);
@@ -328,29 +335,35 @@ namespace PackageExplorerViewModel
             return result;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling"), System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
-        private async Task LoadPackages()
+        private void ShowPackages(IEnumerable<IPackageSearchMetadata> packages, int beginPackage, int endPackage)
         {
-            IsEditable = false;
-            ClearPackages(isErrorCase: true);
-
-            CurrentCancellationTokenSource = new CancellationTokenSource();
-            var usedTokenSource = CurrentCancellationTokenSource;
-
-            var repository = GetPackageRepository();
-
-            if (repository == null)
+            Packages.Clear();
+            if (ActiveRepository != null)
             {
-                await LoadPage(CurrentCancellationTokenSource.Token);
-                return;
+                Packages.AddRange(packages.Select(p => new PackageInfoViewModel(p, ShowPrereleasePackages, ActiveRepository, _feedType, this)));
             }
-
-            _currentQuery = new ShowLatestVersionQueryContext<IPackageSearchMetadata>(repository, _currentSearch, ShowPrereleasePackages, ShowLatestVersionPageSize);
-            _feedType = await repository.GetFeedType(usedTokenSource.Token);
-
-            await LoadPage(CurrentCancellationTokenSource.Token);
+            UpdatePageNumber(beginPackage, endPackage);
+        }
+        
+        private void UpdatePageNumber(int beginPackage, int endPackage)
+        {
+            BeginPackage = beginPackage;
+            EndPackage = endPackage;
+        }
+        
+        private void AutoSelectFirstAvailablePackage()
+        {
+            SelectedPackageViewModel = Packages?.FirstOrDefault();
         }
 
+        private void RestoreUI()
+        {
+            IsEditable = true;
+            CurrentCancellationTokenSource = null;
+            LoadPackagesCompleted(this, EventArgs.Empty);
+        }
+        
+        #region Search
         private async void Search(string searchTerm)
         {
             searchTerm = searchTerm ?? CurrentTypingSearch ?? string.Empty;
@@ -378,6 +391,7 @@ namespace PackageExplorerViewModel
         {
             return IsEditable && !string.IsNullOrEmpty(_currentSearch);
         }
+        #endregion
 
         private async void ChangePackageSource(string source)
         {
@@ -395,38 +409,13 @@ namespace PackageExplorerViewModel
                 await LoadPackages();
             }
         }
-
-        private void UpdatePageNumber(int beginPackage, int endPackage)
+        
+        private void ResetPackageRepository()
         {
-            BeginPackage = beginPackage;
-            EndPackage = endPackage;
+            ActiveRepository = null;
         }
 
-        private void AutoSelectFirstAvailablePackage()
-        {
-            SelectedPackageViewModel = Packages?.FirstOrDefault();
-        }
-
-        private void ClearPackages(bool isErrorCase)
-        {
-            Packages.Clear();
-            if (isErrorCase)
-            {
-                UpdatePageNumber(0, 0);
-            }
-        }
-
-        private void ShowPackages(
-            IEnumerable<IPackageSearchMetadata> packages, int beginPackage, int endPackage)
-        {
-            Packages.Clear();
-            if (_packageRepository != null)
-            {
-                Packages.AddRange(packages.Select(p => new PackageInfoViewModel(p, ShowPrereleasePackages, _packageRepository, _feedType, this)));
-            }
-            UpdatePageNumber(beginPackage, endPackage);
-        }
-
+        #region Status Bar
         private void ShowMessage(string message, bool isError)
         {
             StatusContent = message;
@@ -437,17 +426,16 @@ namespace PackageExplorerViewModel
         {
             ShowMessage(string.Empty, isError: false);
         }
+        #endregion
+
+        private async void OnShowPrereleasePackagesChange()
+        {
+            await LoadPackages();
+        }
 
         public void OnAfterShow()
         {
             CurrentTypingSearch = _currentSearch;
-        }
-
-        private void RestoreUI()
-        {
-            IsEditable = true;
-            CurrentCancellationTokenSource = null;
-            LoadPackagesCompleted(this, EventArgs.Empty);
         }
 
         internal void OnOpenPackage()
@@ -575,10 +563,7 @@ namespace PackageExplorerViewModel
                 _packageSourceManager = null;
             }
 
-            if (CurrentCancellationTokenSource != null)
-            {
-                CurrentCancellationTokenSource.Dispose();
-            }
+            CurrentCancellationTokenSource?.Dispose();
         }
     }
 }

--- a/PackageViewModel/PackageViewModelFactory.cs
+++ b/PackageViewModel/PackageViewModelFactory.cs
@@ -80,11 +80,11 @@ namespace PackageExplorerViewModel
 
         public PackageChooserViewModel CreatePackageChooserViewModel(string fixedPackageSource)
         {
-            var model = new PackageChooserViewModel(
-                new MruPackageSourceManager(new PackageSourceSettings(SettingsManager)),
-                SettingsManager.ShowPrereleasePackages,
-                SettingsManager.AutoLoadPackages,
-                fixedPackageSource);
+            var packageSourceSettings = new PackageSourceSettings(SettingsManager);
+            var packageSourceManager = new MruPackageSourceManager(packageSourceSettings);
+            var model = new PackageChooserViewModel(packageSourceManager,
+                                                    SettingsManager.ShowPrereleasePackages,
+                                                    fixedPackageSource);
             model.PropertyChanged += OnPackageChooserViewModelPropertyChanged;
             return model;
         }
@@ -103,10 +103,6 @@ namespace PackageExplorerViewModel
             if (e.PropertyName == "ShowPrereleasePackages")
             {
                 SettingsManager.ShowPrereleasePackages = model.ShowPrereleasePackages;
-            }
-            else if (e.PropertyName == "AutoLoadPackages")
-            {
-                SettingsManager.AutoLoadPackages = model.AutoLoadPackages;
             }
         }
     }


### PR DESCRIPTION
![https://thumbs.gfycat.com/EnchantingHelpfulFlamingo-size_restricted.gif](https://thumbs.gfycat.com/EnchantingHelpfulFlamingo-size_restricted.gif)

* After the packages have been loaded, the first package will be
  automatically selected so that the details view doesn't look empty.
  The detail view is also updated when the selection changes using the
  up/down arrow keys.
* PackageChooserDialog.xaml.cs > CancelPendingRequestAndCloseDialog():
  set the selected package field to null to prevents the package from
  being loaded into the main window after the package chooser is hidden.

ref: #398 