### PR TITLE
use semantic verison in PackageChooser

### DIFF
--- a/Core/Packages/PackageInfo.cs
+++ b/Core/Packages/PackageInfo.cs
@@ -29,6 +29,7 @@ namespace NuGetPe
         public string Tags { get; set; }
         public string ReportAbuseUrl { get; set; }
 
+        public bool IsPrefixReserved { get; set; }
         public bool IsRemotePackage { get; set; }
 
         public bool IsUnlisted

--- a/PackageExplorer/App.xaml
+++ b/PackageExplorer/App.xaml
@@ -10,6 +10,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Xaml/MenuItems.xaml" />
                 <ResourceDictionary Source="Xaml/Toolbar.xaml" />
+                <ResourceDictionary Source="Xaml/PrefixReservedIndicator.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
             <self:IntegerToBooleanConverter x:Key="FontSizeToBoolConverter" />

--- a/PackageExplorer/PackageChooser/PackageChooserDialog.xaml
+++ b/PackageExplorer/PackageChooser/PackageChooserDialog.xaml
@@ -148,9 +148,14 @@
                                VerticalAlignment="Top" HorizontalAlignment="Left"
                                Style="{StaticResource PackageIconImageStyle}"/>
 
-                        <StackPanel Orientation="Vertical" Grid.Column="1" Grid.Row="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                            <TextBlock HorizontalAlignment="Stretch">
-                                <Run Text="{Binding LatestPackageInfo.Id, Mode=OneWay}" FontWeight="Bold"/> by
+                        <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                            <TextBlock Text="{Binding LatestPackageInfo.Id, Mode=OneWay}" FontWeight="Bold"/>
+                            <Rectangle Fill="{StaticResource PrefixReservedIndicator}" 
+                                       Width="16" Height="16" 
+                                       Margin="4,0,0,0"
+                                       Visibility="{Binding LatestPackageInfo.IsPrefixReserved, Converter={StaticResource boolToVis}}"/>
+                            <TextBlock HorizontalAlignment="Stretch" Margin="4,0,0,0">
+                                by
                                 <Run Text="{Binding LatestPackageInfo.Authors, Mode=OneWay}"/>,
                                 <Run Text="{Binding LatestPackageInfo.DownloadCount, Mode=OneWay, Converter={StaticResource NumberToStringConverter}}" FontWeight="Bold"/> downloads
                             </TextBlock>

--- a/PackageExplorer/PackageChooser/PackageChooserDialog.xaml
+++ b/PackageExplorer/PackageChooser/PackageChooserDialog.xaml
@@ -175,7 +175,7 @@
                             </Label.Style>
                             <Label.Content>
                                 <TextBlock>
-                                    v<Run Text="{Binding LatestPackageInfo.Version, Mode=OneWay}"/>
+                                    v<Run Text="{Binding LatestPackageInfo.SemanticVersion, Mode=OneWay}"/>
                                 </TextBlock>
                             </Label.Content>
                         </Label>

--- a/PackageExplorer/PackageChooser/PackageDetailActionsControl.xaml
+++ b/PackageExplorer/PackageChooser/PackageDetailActionsControl.xaml
@@ -77,7 +77,7 @@
                         </GridViewColumn.HeaderContainerStyle>
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>
-                                <TextBlock Text="{Binding Version}" HorizontalAlignment="Right"/>
+                                <TextBlock Text="{Binding SemanticVersion}" HorizontalAlignment="Right"/>
                             </DataTemplate>
                         </GridViewColumn.CellTemplate>
                     </GridViewColumn>

--- a/PackageExplorer/PackageChooser/PackageDetailControl.xaml
+++ b/PackageExplorer/PackageChooser/PackageDetailControl.xaml
@@ -16,6 +16,11 @@
 
                     <!-- Package Name -->
                     <TextBlock Text="{Binding LatestPackageInfo.Id}" TextWrapping="Wrap" FontSize="18" VerticalAlignment="Center" Margin="10,0,0,0"/>
+                    
+                    <Rectangle Fill="{StaticResource PrefixReservedIndicator}" 
+                               Width="18" Height="18"
+                               Margin="5,3,0,0"
+                               Visibility="{Binding LatestPackageInfo.IsPrefixReserved, Converter={StaticResource boolToVis}}"/>
                 </StackPanel>
 
                 <self:PackageDetailActionsControl HorizontalAlignment="Stretch"/>

--- a/PackageExplorer/Xaml/PrefixReservedIndicator.xaml
+++ b/PackageExplorer/Xaml/PrefixReservedIndicator.xaml
@@ -1,0 +1,14 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:PresentationOptions="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options" xmlns:theme="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero">
+    <DrawingBrush x:Key="PrefixReservedIndicator">
+        <DrawingBrush.Drawing>
+            <DrawingGroup>
+                <DrawingGroup.Children>
+                    <GeometryDrawing Brush="#00FFFFFF" Geometry="F1M16,16L0,16 0,0 16,0z" />
+                    <GeometryDrawing Brush="#FFF6F6F6" Geometry="F1M16,8C16,12.411 12.411,16 8,16 3.589,16 0,12.411 0,8 0,3.589 3.589,0 8,0 12.411,0 16,3.589 16,8" />
+                    <GeometryDrawing Brush="#FF1AA1E2" Geometry="F1M6.2998,12.3887L3.0428,9.1317 4.4568,7.7177 6.2998,9.5607 11.5428,4.3177 12.9568,5.7317z M7.9998,0.999700000000001C4.1338,0.999700000000001 0.9998,4.1337 0.9998,7.9997 0.9998,11.8667 4.1338,14.9997 7.9998,14.9997 11.8658,14.9997 14.9998,11.8667 14.9998,7.9997 14.9998,4.1337 11.8658,0.999700000000001 7.9998,0.999700000000001" />
+                    <GeometryDrawing Brush="#FFFFFFFF" Geometry="F1M6.2998,12.3887L3.0428,9.1317 4.4568,7.7177 6.2998,9.5607 11.5428,4.3177 12.9568,5.7317z" />
+                </DrawingGroup.Children>
+            </DrawingGroup>
+        </DrawingBrush.Drawing>
+    </DrawingBrush>
+</ResourceDictionary>

--- a/PackageExplorer/app.config
+++ b/PackageExplorer/app.config
@@ -3,70 +3,10 @@
     <configSections>
         <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
             <section name="PackageExplorer.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
-            <section name="NuGetPackageExplorer.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
         </sectionGroup>
     </configSections>
     <userSettings>
         <PackageExplorer.Properties.Settings>
-            <setting name="FontSize" serializeAs="String">
-                <value>12</value>
-            </setting>
-            <setting name="ContentViewerHeight" serializeAs="String">
-                <value>400</value>
-            </setting>
-            <setting name="PackageSource" serializeAs="String">
-                <value>https://api.nuget.org/v3/index.json</value>
-            </setting>
-            <setting name="WindowPlacement" serializeAs="String">
-                <value />
-            </setting>
-            <setting name="PublishPrivateKey" serializeAs="String">
-                <value />
-            </setting>
-            <setting name="PublishPackageLocation" serializeAs="String">
-                <value>https://nuget.org</value>
-            </setting>
-            <setting name="PackageChooserDialogWidth" serializeAs="String">
-                <value>630</value>
-            </setting>
-            <setting name="PackageChooserDialogHeight" serializeAs="String">
-                <value>450</value>
-            </setting>
-            <setting name="IsFirstTime" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="PackageContentHeight" serializeAs="String">
-                <value>400</value>
-            </setting>
-            <setting name="ShowTaskShortcuts" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="WordWrap" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="ShowLineNumbers" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="PublishAsUnlisted" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="ShowPrereleasePackages" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="IsFirstTimeAfterMigrate" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="SigningCertificate" serializeAs="String">
-                <value />
-            </setting>
-            <setting name="TimestampServer" serializeAs="String">
-                <value />
-            </setting>
-            <setting name="SigningHashAlgorithmName" serializeAs="String">
-                <value />
-            </setting>
-        </PackageExplorer.Properties.Settings>
-        <NuGetPackageExplorer.Properties.Settings>
             <setting name="FontSize" serializeAs="String">
                 <value>12</value>
             </setting>
@@ -121,7 +61,7 @@
             <setting name="UseApiKey" serializeAs="String">
                 <value>True</value>
             </setting>
-        </NuGetPackageExplorer.Properties.Settings>
+        </PackageExplorer.Properties.Settings>
     </userSettings>
     <system.net>
         <settings>

--- a/PackageViewModel/PackageChooser/PackageInfoViewModel.cs
+++ b/PackageViewModel/PackageChooser/PackageInfoViewModel.cs
@@ -303,6 +303,7 @@ namespace PackageExplorerViewModel
                 Published = packageSearchMetadata.Published,
                 DownloadCount = (int)(versionInfo?.DownloadCount ?? packageSearchMetadata.DownloadCount.GetValueOrDefault()),
                 IsRemotePackage = (feedType == FeedType.HttpV3 || feedType == FeedType.HttpV2),
+                IsPrefixReserved = packageSearchMetadata.PrefixReserved,
                 Description = packageSearchMetadata.Description,
                 Tags = packageSearchMetadata.Tags,
                 Summary = packageSearchMetadata.Summary,


### PR DESCRIPTION
The `SemanticVersion.ToString()`  method returns versions without the `+...` part.

Fixes last part of https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/pull/405#issuecomment-385183453