### PR TITLE
do not allow setting SelectedPackage to null

### DIFF
--- a/PackageViewModel/PackageChooser/PackageInfoViewModel.cs
+++ b/PackageViewModel/PackageChooser/PackageInfoViewModel.cs
@@ -74,7 +74,10 @@ namespace PackageExplorerViewModel
             {
                 if (_selectedPackage != value)
                 {
-                    _selectedPackage = value;
+                    if (value != null)
+                    {
+                        _selectedPackage = value;
+                    }
                     OnPropertyChanged();
                 }
             }


### PR DESCRIPTION
with `Strg + Click` in package versions list. Because it is now used to display the package details.

Before this looked like this:
![image](https://user-images.githubusercontent.com/4009570/39400498-ae34ba42-4b31-11e8-8224-e758716695be.png)
