### PR TITLE
Use the local cache location

### DIFF
--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -5,6 +5,9 @@
     <RootNamespace>NuGetPe</RootNamespace>
     <Description>Core library which is responsible for loading .nupkg files and parsing .nuspec files.</Description>
     <Title>NuGet Package Explorer Core</Title>
+
+    <TargetPlatformMinVersion>10.0.10563.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion>10.0.17134.0</TargetPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,6 +18,12 @@
   <ItemGroup>
     <ProjectReference Include="..\Types\Types.csproj" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" />
+
+    <Reference Include="Windows">
+      <HintPath Condition="Exists('$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\$(TargetPlatformMinVersion)\Windows.winmd')">$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\$(TargetPlatformMinVersion)\Windows.winmd</HintPath>
+      <HintPath Condition="Exists('$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\$(TargetPlatformVersion)\Windows.winmd')">$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\$(TargetPlatformVersion)\Windows.winmd</HintPath>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
   
 </Project>

--- a/Core/Repositories/MachineCache.cs
+++ b/Core/Repositories/MachineCache.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Security;
+using Windows.Storage;
 using NuGet.Versioning;
 
 namespace NuGetPe
@@ -129,6 +130,18 @@ namespace NuGetPe
         /// </summary>
         private static string GetCachePath()
         {
+            // Try getting it from the app model first
+            try
+            {
+                // Get the localized special folder for local app data
+                var local = new DirectoryInfo(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)).Name;
+                return GetCachePath(Environment.GetEnvironmentVariable, _ => Path.Combine(ApplicationData.Current.LocalCacheFolder.Path, local));
+            }
+            catch
+            { 
+                // Don't care here, not on Win7 or running in an app model context
+            }
+
             return GetCachePath(Environment.GetEnvironmentVariable, Environment.GetFolderPath);
         }
 


### PR DESCRIPTION
File writes are virtualized when running in an Appx. Ensure the View local cache and clear local cache point to the right folders.