### PR TITLE
fix saving packages multiple times

### DIFF
--- a/Core/Packages/PackageFileBase.cs
+++ b/Core/Packages/PackageFileBase.cs
@@ -23,7 +23,7 @@ namespace NuGetPe
         public string Path
         {
             get;
-            private set;
+            set;
         }
 
         public virtual string OriginalPath

--- a/Core/Packages/ZipPackageFile.cs
+++ b/Core/Packages/ZipPackageFile.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Diagnostics;
 using System.IO;
-using System.IO.Compression;
-using NuGet.Packaging;
 
 namespace NuGetPe
 {
@@ -10,12 +7,24 @@ namespace NuGetPe
     {
         private readonly Func<Stream> _streamFactory;
 
-        public ZipPackageFile(PackageArchiveReader reader, ZipArchiveEntry entry)
-            : base(UnescapePath(entry.FullName.Replace('/', '\\')))
+        public ZipPackageFile(string entryFullName, DateTimeOffset lastWriteTime, Func<string, Stream> entryStreamFactory)
+            : base(UnescapePath(entryFullName.Replace('/', '\\')))
         {
-            Debug.Assert(reader != null, "reader should not be null");
-            LastWriteTime = entry.LastWriteTime;
-            _streamFactory = () => reader.GetStream(UnescapePath(entry.FullName));
+            entryFullName = UnescapePath(entryFullName);
+            LastWriteTime = lastWriteTime;
+            _streamFactory = () =>
+            {
+                try
+                {
+                    return entryStreamFactory(entryFullName);
+                }
+                catch (FileNotFoundException) // file has been renamed / moved
+                {
+                    entryFullName = UnescapePath(Path);
+
+                    return entryStreamFactory(entryFullName);
+                }
+            };
         }
 
         // code copied from https://github.com/NuGet/NuGet.Client/blob/91023394890b1458ec0c5940128da73e04089869/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs#L36-L45

--- a/PackageViewModel/PackagePart/PackageFile.cs
+++ b/PackageViewModel/PackagePart/PackageFile.cs
@@ -34,6 +34,20 @@ namespace PackageExplorerViewModel
 
         #region IPackageFile members
 
+        public override string Path
+        {
+            get => base.Path;
+            set
+            {
+                base.Path = value;
+
+                if (_file is PackageFileBase packageFile)
+                {
+                    packageFile.Path = value;
+                }
+            }
+        }
+
         /// <summary>
         /// Returns the path on disk if this file is a PhysicalPackageFile. Otherwise, returns null;
         /// </summary>

--- a/PackageViewModel/PackagePart/PackagePart.cs
+++ b/PackageViewModel/PackagePart/PackagePart.cs
@@ -89,7 +89,7 @@ namespace PackageExplorerViewModel
             }
         }
 
-        public string Path
+        public virtual string Path
         {
             get { return _path; }
             set


### PR DESCRIPTION
The problem was that the package reader is in an invalid state after the package has been saved, which resulted in an exception if the package was saved again.
Catching the exception and reading the package again fixes the issue, but if a file was renamed the `Path` of the `ZipPackageFile` was never updated which resulted in another exception.
Which I have fixed by also updating the Path and using it as a fallback.

fixes #376