### PR TITLE
do not lock package file if no changes are made

### DIFF
--- a/Core/Packages/PackageFileBase.cs
+++ b/Core/Packages/PackageFileBase.cs
@@ -23,7 +23,7 @@ namespace NuGetPe
         public string Path
         {
             get;
-            set;
+            private set;
         }
 
         public virtual string OriginalPath

--- a/Core/Packages/ZipPackageFile.cs
+++ b/Core/Packages/ZipPackageFile.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
+using System.IO.Compression;
+using NuGet.Packaging;
 
 namespace NuGetPe
 {
@@ -7,24 +10,12 @@ namespace NuGetPe
     {
         private readonly Func<Stream> _streamFactory;
 
-        public ZipPackageFile(string entryFullName, DateTimeOffset lastWriteTime, Func<string, Stream> entryStreamFactory)
-            : base(UnescapePath(entryFullName.Replace('/', '\\')))
+        public ZipPackageFile(PackageArchiveReader reader, ZipArchiveEntry entry)
+            : base(UnescapePath(entry.FullName.Replace('/', '\\')))
         {
-            entryFullName = UnescapePath(entryFullName);
-            LastWriteTime = lastWriteTime;
-            _streamFactory = () =>
-            {
-                try
-                {
-                    return entryStreamFactory(entryFullName);
-                }
-                catch (FileNotFoundException) // file has been renamed / moved
-                {
-                    entryFullName = UnescapePath(Path);
-
-                    return entryStreamFactory(entryFullName);
-                }
-            };
+            Debug.Assert(reader != null, "reader should not be null");
+            LastWriteTime = entry.LastWriteTime;
+            _streamFactory = () => reader.GetStream(UnescapePath(entry.FullName));
         }
 
         // code copied from https://github.com/NuGet/NuGet.Client/blob/91023394890b1458ec0c5940128da73e04089869/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs#L36-L45

--- a/PackageExplorer/MainWindow.xaml.cs
+++ b/PackageExplorer/MainWindow.xaml.cs
@@ -90,6 +90,8 @@ namespace PackageExplorer
         [Export]
         public IPackageEditorService EditorService { get; set; }
 
+        private string _tempFile;
+
         private bool HasUnsavedChanges
         {
             get
@@ -146,18 +148,21 @@ namespace PackageExplorer
         {
             IPackage package = null;
 
+            var tempFile = Path.GetTempFileName();
             try
             {
+                File.Copy(packagePath, tempFile, overwrite: true);
+
                 var extension = Path.GetExtension(packagePath);
                 if (extension.Equals(Constants.PackageExtension, StringComparison.OrdinalIgnoreCase))
                 {
-                    package = new ZipPackage(packagePath);
+                    package = new ZipPackage(tempFile);
                 }
                 else if (extension.Equals(Constants.ManifestExtension, StringComparison.OrdinalIgnoreCase))
                 {
-                    using (var str = ManifestUtility.ReadManifest(packagePath))
+                    using (var str = ManifestUtility.ReadManifest(tempFile))
                     {
-                        var builder = new PackageBuilder(str, Path.GetDirectoryName(packagePath));
+                        var builder = new PackageBuilder(str, Path.GetDirectoryName(tempFile));
                         package = builder.Build();
                     }
                 }
@@ -165,13 +170,22 @@ namespace PackageExplorer
                 if (package != null)
                 {
                     LoadPackage(package, packagePath, PackageType.LocalPackage);
+                    _tempFile = tempFile;
                     return true;
                 }
             }
             catch (Exception ex)
             {
+                package = null;
                 UIServices.Show(ex.Message, MessageLevel.Error);
                 return false;
+            }
+            finally
+            {
+                if (package == null && File.Exists(tempFile))
+                {
+                    File.Delete(tempFile);
+                }
             }
 
             return false;
@@ -244,6 +258,14 @@ namespace PackageExplorer
             {
                 currentViewModel.PropertyChanged -= OnPackageViewModelPropertyChanged;
                 currentViewModel.Dispose();
+            }
+            if (_tempFile != null)
+            {
+                if (File.Exists(_tempFile))
+                {
+                    File.Delete(_tempFile);
+                }
+                _tempFile = null;
             }
         }
 
@@ -461,7 +483,7 @@ namespace PackageExplorer
                 return;
             }
 
-            (DataContext as PackageViewModel)?.Dispose();
+            DisposeViewModel();
             DataContext = null;
         }
 

--- a/PackageExplorer/MainWindow.xaml.cs
+++ b/PackageExplorer/MainWindow.xaml.cs
@@ -184,7 +184,11 @@ namespace PackageExplorer
             {
                 if (package == null && File.Exists(tempFile))
                 {
-                    File.Delete(tempFile);
+                    try
+                    {
+                        File.Delete(tempFile);
+                    }
+                    catch { /* ignore */ }
                 }
             }
 
@@ -263,7 +267,11 @@ namespace PackageExplorer
             {
                 if (File.Exists(_tempFile))
                 {
-                    File.Delete(_tempFile);
+                    try
+                    {
+                        File.Delete(_tempFile);
+                    }
+                    catch { /* ignore */ }
                 }
                 _tempFile = null;
             }

--- a/PackageViewModel/Commands/SavePackageCommand.cs
+++ b/PackageViewModel/Commands/SavePackageCommand.cs
@@ -82,7 +82,7 @@ namespace PackageExplorerViewModel
 
             if (action == SaveAction || action == ForceSaveAction)
             {
-                if (CanSaveTo(ViewModel.PackageSource))
+                if (CanSaveTo(ViewModel.PackageSource) && !ViewModel.HasFileChangedExternally)
                 {
                     Save();
                 }

--- a/PackageViewModel/PackagePart/PackageFile.cs
+++ b/PackageViewModel/PackagePart/PackageFile.cs
@@ -34,20 +34,6 @@ namespace PackageExplorerViewModel
 
         #region IPackageFile members
 
-        public override string Path
-        {
-            get => base.Path;
-            set
-            {
-                base.Path = value;
-
-                if (_file is PackageFileBase packageFile)
-                {
-                    packageFile.Path = value;
-                }
-            }
-        }
-
         /// <summary>
         /// Returns the path on disk if this file is a PhysicalPackageFile. Otherwise, returns null;
         /// </summary>

--- a/PackageViewModel/PackagePart/PackagePart.cs
+++ b/PackageViewModel/PackagePart/PackagePart.cs
@@ -89,7 +89,7 @@ namespace PackageExplorerViewModel
             }
         }
 
-        public virtual string Path
+        public string Path
         {
             get { return _path; }
             set

--- a/PackageViewModel/PackageViewModel.cs
+++ b/PackageViewModel/PackageViewModel.cs
@@ -61,6 +61,7 @@ namespace PackageExplorerViewModel
         private ICommand _viewContentCommand;
         private ICommand _viewPackageAnalysisCommand;
         private ICommand _removeSignatureCommand;
+        private FileSystemWatcher _watcher;
 
         #endregion
 
@@ -244,6 +245,20 @@ namespace PackageExplorerViewModel
                 {
                     _packageSource = value;
                     OnPropertyChanged("PackageSource");
+
+                    if (File.Exists(PackageSource))
+                    {
+                        if (_watcher == null)
+                        {
+                            _watcher = new FileSystemWatcher();
+                            _watcher.Changed += OnFileChange;
+                            _watcher.Deleted += OnFileChange;
+                            _watcher.Renamed += OnFileChange;
+                        }
+                        _watcher.Path = Path.GetDirectoryName(PackageSource);
+                        _watcher.Filter = Path.GetFileName(PackageSource);
+                        _watcher.EnableRaisingEvents = true;
+                    }
                 }
             }
         }
@@ -261,6 +276,8 @@ namespace PackageExplorerViewModel
             }
         }
 
+        public bool HasFileChangedExternally { get; private set; }
+
         public ObservableCollection<PackageIssue> PackageIssues
         {
             get { return _packageIssues; }
@@ -277,6 +294,14 @@ namespace PackageExplorerViewModel
         {
             RootFolder.Dispose();
             _package.Dispose();
+
+            if (_watcher != null)
+            {
+                _watcher.Changed -= OnFileChange;
+                _watcher.Deleted -= OnFileChange;
+                _watcher.Renamed -= OnFileChange;
+                _watcher.Dispose();
+            }
         }
 
         #endregion
@@ -1118,6 +1143,11 @@ namespace PackageExplorerViewModel
 
         #endregion
 
+        private void OnFileChange(object sender, FileSystemEventArgs e)
+        {
+            HasFileChangedExternally = true;
+        }
+
         private void SetPackageIssues(IEnumerable<PackageIssue> issues)
         {
             _packageIssues.Clear();
@@ -1195,6 +1225,7 @@ namespace PackageExplorerViewModel
         internal void OnSaved(string fileName)
         {
             HasEdit = false;
+            HasFileChangedExternally = false;
             _mruManager.NotifyFileAdded(PackageMetadata, fileName, PackageType.LocalPackage);
         }
 


### PR DESCRIPTION
- If the users makes changes to the package without saving them the package will be locked to prevent deletion / renames.
- A new Package Archive reader is created for each `GetStream` call...
- If the package is deleted / renamed or modified NPE will show a message box. And in case of modifications automatically reloads the package.

fixes #434