### PR TITLE
Show nuspec XML for signed packages

### DIFF
--- a/PackageExplorer/FileEditor.xaml
+++ b/PackageExplorer/FileEditor.xaml
@@ -82,9 +82,9 @@
                 </Button>
             
                 <!-- Save -->
-                <Button ToolTip="Save (Ctrl+S)" Command="{Binding SaveCommand, Mode=OneWay}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type self:FileEditor}}}">
-                    <Image Source="Images/SaveHS.png" />
-                </Button>
+                <self:GrayscaleButton ToolTip="Save (Ctrl+S)" Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" Command="{Binding SaveCommand, Mode=OneWay}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type self:FileEditor}}}">
+                    <self:GrayscaleImage Source="Images/SaveHS.png" />
+                </self:GrayscaleButton>
 
                 <Separator />
 
@@ -167,6 +167,7 @@
             ShowLineNumbers="{Binding ShowLineNumbers, Source={StaticResource Settings}, Mode=OneWay}" 
             SyntaxHighlighting="{Binding SelectedItem, ElementName=SyntaxDefinitions, Mode=OneWay}" 
             FontFamily="{Binding SelectedItem, ElementName=FontChoice}"
+            IsReadOnly="{Binding IsReadOnly, Mode=OneWay}"
             />
     </DockPanel>
 </UserControl>

--- a/PackageExplorer/PackageViewer.xaml
+++ b/PackageExplorer/PackageViewer.xaml
@@ -568,9 +568,7 @@
                 </Grid.RowDefinitions>
 
                 <!-- Toolbar for package metadata pane --> 
-                <Border Grid.Row="0" Background="#BCC7D8" Padding="3" BorderBrush="{StaticResource {x:Static SystemColors.ActiveBorderBrushKey}}" BorderThickness="0,1,0,0"
-                        Visibility="{Binding IsSigned, Converter={StaticResource invertedBoolToVis}}"
-                        >
+                <Border Grid.Row="0" Background="#BCC7D8" Padding="3" BorderBrush="{StaticResource {x:Static SystemColors.ActiveBorderBrushKey}}" BorderThickness="0,1,0,0">
                     <StackPanel Orientation="Horizontal">
                         <Button 
                             Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" 

--- a/PackageExplorer/PackageViewer.xaml
+++ b/PackageExplorer/PackageViewer.xaml
@@ -575,7 +575,7 @@
                             Command="{Binding EditCommand, Mode=OneWay}" 
                             Margin="2,0,0,0" 
                             Padding="1,0,0,0"
-                            Visibility="{Binding IsInEditMetadataMode, Converter={StaticResource invertedBoolToVis}}"
+                            Visibility="{Binding IsSignedOrInEditMetadataMode, Converter={StaticResource invertedBoolToVis}}"
                             ToolTipService.ToolTip="Edit Metadata (Ctrl+K)">
                             <Image Source="Images/EditHS.png" />
                         </Button>

--- a/PackageViewModel/FileEditorViewModel.cs
+++ b/PackageViewModel/FileEditorViewModel.cs
@@ -28,7 +28,7 @@ namespace PackageExplorerViewModel
             _filePath = fileInEdit.OriginalPath ?? Path.Combine(FileHelper.GetTempFilePath(), fileInEdit.Name);
 
             _closeCommand = new RelayCommand<IFileEditorService>(CloseExecute);
-            _saveCommand = new RelayCommand<IFileEditorService>(SaveExecute);
+            _saveCommand = new RelayCommand<IFileEditorService>(SaveExecute, CanSaveExecute);
         }
 
         public IPackageFile FileInEdit
@@ -47,6 +47,11 @@ namespace PackageExplorerViewModel
                     OnPropertyChanged("HasEdit");
                 }
             }
+        }
+
+        public bool IsReadOnly
+        {
+            get { return _packageViewModel.IsSigned; }
         }
 
         #region CloseCommand
@@ -89,6 +94,11 @@ namespace PackageExplorerViewModel
         public ICommand SaveCommand
         {
             get { return _saveCommand; }
+        }
+
+        private bool CanSaveExecute(IFileEditorService obj)
+        {
+            return !IsReadOnly;
         }
 
         private void SaveExecute(IFileEditorService editorService)

--- a/PackageViewModel/PackageViewModel.cs
+++ b/PackageViewModel/PackageViewModel.cs
@@ -469,7 +469,7 @@ namespace PackageExplorerViewModel
 
         private bool EditPackageCanExecute()
         {
-            return !IsSigned && !IsInEditMetadataMode && !IsInEditFileMode;
+            return !IsInEditMetadataMode && !IsInEditFileMode;
         }
 
         private void EditPackageExecute()
@@ -516,7 +516,7 @@ namespace PackageExplorerViewModel
             {
                 if (_cancelEditCommand == null)
                 {
-                    _cancelEditCommand = new RelayCommand(CancelEditExecute, () => !IsSigned && !IsInEditFileMode);
+                    _cancelEditCommand = new RelayCommand(CancelEditExecute, () => !IsInEditFileMode);
                 }
 
                 return _cancelEditCommand;
@@ -986,7 +986,7 @@ namespace PackageExplorerViewModel
 
         private bool CanEditMetadataSourceCommandExecute()
         {
-            return !IsSigned && !IsInEditFileMode && !IsInEditMetadataMode;
+            return !IsInEditFileMode && !IsInEditMetadataMode;
         }
 
         private IEditablePackageFile CreatePackageMetadataFile()

--- a/PackageViewModel/PackageViewModel.cs
+++ b/PackageViewModel/PackageViewModel.cs
@@ -124,6 +124,11 @@ namespace PackageExplorerViewModel
             }
         }
 
+        public bool IsSignedOrInEditMetadataMode
+        {
+            get { return IsInEditMetadataMode || IsSigned; }
+        }
+
         public bool IsInEditFileMode
         {
             get { return FileEditorViewModel != null; }
@@ -469,7 +474,7 @@ namespace PackageExplorerViewModel
 
         private bool EditPackageCanExecute()
         {
-            return !IsInEditMetadataMode && !IsInEditFileMode;
+            return !IsSigned && !IsInEditMetadataMode && !IsInEditFileMode;
         }
 
         private void EditPackageExecute()
@@ -516,7 +521,7 @@ namespace PackageExplorerViewModel
             {
                 if (_cancelEditCommand == null)
                 {
-                    _cancelEditCommand = new RelayCommand(CancelEditExecute, () => !IsInEditFileMode);
+                    _cancelEditCommand = new RelayCommand(CancelEditExecute, () => !IsSigned && !IsInEditFileMode);
                 }
 
                 return _cancelEditCommand;


### PR DESCRIPTION
Adds the ability to view nuspec xml's for signed packages. I've made sure to disable the save commands where I could find them.

Not sure if this is sufficient, please let me know if I missed something.

Addresses #478 