### PR TITLE
Display PDB information

### DIFF
--- a/Core/AssemblyMetadata/AssemblyDebugData.cs
+++ b/Core/AssemblyMetadata/AssemblyDebugData.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Diagnostics;
+using System.Security.Cryptography;
+
+namespace NuGetPe.AssemblyMetadata
+{
+    [DebuggerDisplay("{Name}")]
+    public class AssemblyDebugData
+    {
+        private static readonly Guid CSharp = new Guid("3f5162f8-07c6-11d3-9053-00c04fa302a1");
+        private static readonly Guid VisualBasic = new Guid("3a12d0b8-c26c-11d0-b442-00a0244a1dd2");
+        private static readonly Guid FSharp = new Guid("ab4f38c9-b6e6-43ba-be3b-58080b2ccce3");
+
+        private static readonly Guid Sha1 = new Guid("ff1816ec-aa5e-4d10-87f7-6f4963833460");
+        private static readonly Guid Sha256 = new Guid("8829d00f-11b8-4213-878b-770e8597ac16");
+
+        internal AssemblyDebugData(string name, byte[] hash, Guid language, Guid hashAlgorithm)
+        {
+            Name = name;
+            Hash = hash;
+            Language = LanguageFromGuid(language);
+            HashAlgorithm = HashAlgorithmNameFromGuid(hashAlgorithm);
+        }
+
+        public string Name { get; }
+        public byte[] Hash { get; }
+        public SymbolLanguage Language { get; }
+        public HashAlgorithmName HashAlgorithm { get; }
+
+        private SymbolLanguage LanguageFromGuid(Guid guid)
+        {
+            if (guid == CSharp) return SymbolLanguage.CSharp;
+            if (guid == VisualBasic) return SymbolLanguage.VisualBasic;
+            if (guid == FSharp) return SymbolLanguage.FSharp;
+
+            throw new ArgumentOutOfRangeException(nameof(guid));
+        }
+
+
+        public HashAlgorithmName HashAlgorithmNameFromGuid(Guid guid)
+        {
+            if (guid == Sha1) return HashAlgorithmName.SHA1;
+            if (guid == Sha256) return HashAlgorithmName.SHA256;
+
+            throw new ArgumentOutOfRangeException(nameof(guid));
+        }
+    }
+
+    public enum SymbolLanguage
+    {
+        CSharp,
+        VisualBasic,
+        FSharp
+    }
+}

--- a/Core/AssemblyMetadata/AssemblyDebugData.cs
+++ b/Core/AssemblyMetadata/AssemblyDebugData.cs
@@ -8,8 +8,17 @@ namespace NuGetPe.AssemblyMetadata
 {
     public class AssemblyDebugData
     {
-        public IReadOnlyList<SourceLinkMap> SourceLink { get; set; }
+        public PdbType PdbType { get; internal set; }
+
+        public IReadOnlyList<SourceLinkMap> SourceLink { get; internal set; }
 
         public IReadOnlyList<AssemblyDebugSourceDocument> Sources { get; internal set; }
+    }
+
+    public enum PdbType
+    {
+        Portable,
+        Embedded,
+        Full
     }
 }

--- a/Core/AssemblyMetadata/AssemblyDebugData.cs
+++ b/Core/AssemblyMetadata/AssemblyDebugData.cs
@@ -1,55 +1,15 @@
 ﻿using System;
-using System.Diagnostics;
-using System.Security.Cryptography;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace NuGetPe.AssemblyMetadata
 {
-    [DebuggerDisplay("{Name}")]
     public class AssemblyDebugData
     {
-        private static readonly Guid CSharp = new Guid("3f5162f8-07c6-11d3-9053-00c04fa302a1");
-        private static readonly Guid VisualBasic = new Guid("3a12d0b8-c26c-11d0-b442-00a0244a1dd2");
-        private static readonly Guid FSharp = new Guid("ab4f38c9-b6e6-43ba-be3b-58080b2ccce3");
+        public IReadOnlyList<SourceLinkMap> SourceLink { get; set; }
 
-        private static readonly Guid Sha1 = new Guid("ff1816ec-aa5e-4d10-87f7-6f4963833460");
-        private static readonly Guid Sha256 = new Guid("8829d00f-11b8-4213-878b-770e8597ac16");
-
-        internal AssemblyDebugData(string name, byte[] hash, Guid language, Guid hashAlgorithm)
-        {
-            Name = name;
-            Hash = hash;
-            Language = LanguageFromGuid(language);
-            HashAlgorithm = HashAlgorithmNameFromGuid(hashAlgorithm);
-        }
-
-        public string Name { get; }
-        public byte[] Hash { get; }
-        public SymbolLanguage Language { get; }
-        public HashAlgorithmName HashAlgorithm { get; }
-
-        private SymbolLanguage LanguageFromGuid(Guid guid)
-        {
-            if (guid == CSharp) return SymbolLanguage.CSharp;
-            if (guid == VisualBasic) return SymbolLanguage.VisualBasic;
-            if (guid == FSharp) return SymbolLanguage.FSharp;
-
-            throw new ArgumentOutOfRangeException(nameof(guid));
-        }
-
-
-        public HashAlgorithmName HashAlgorithmNameFromGuid(Guid guid)
-        {
-            if (guid == Sha1) return HashAlgorithmName.SHA1;
-            if (guid == Sha256) return HashAlgorithmName.SHA256;
-
-            throw new ArgumentOutOfRangeException(nameof(guid));
-        }
-    }
-
-    public enum SymbolLanguage
-    {
-        CSharp,
-        VisualBasic,
-        FSharp
+        public IReadOnlyList<AssemblyDebugSourceDocument> Sources { get; internal set; }
     }
 }

--- a/Core/AssemblyMetadata/AssemblyDebugParser.cs
+++ b/Core/AssemblyMetadata/AssemblyDebugParser.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Metadata;
+using System.Text;
+using Newtonsoft.Json.Linq;
 
 namespace NuGetPe.AssemblyMetadata
 {
@@ -18,19 +20,59 @@ namespace NuGetPe.AssemblyMetadata
         private readonly MetadataReaderProvider _readerProvider;
         private readonly MetadataReader _reader;
 
+        private static readonly Guid SourceLinkGuid = new Guid("CC110556-A091-4D38-9FEC-25AB9A351A6A");
 
-        public IReadOnlyList<AssemblyDebugData> GetDebugData()
+
+        public AssemblyDebugData GetDebugData()
+        {
+            var debugData = new AssemblyDebugData();
+
+            
+
+            debugData.Sources = GetSourceDocuments();
+            debugData.SourceLink = GetSourceLinkInformation(); 
+
+            return debugData;
+        }
+
+        private IReadOnlyList<SourceLinkMap> GetSourceLinkInformation()
+        {
+            var sl = (from cdi in _reader.CustomDebugInformation
+                       let cd = _reader.GetCustomDebugInformation(cdi)
+                       let kind = _reader.GetGuid(cd.Kind)
+                       where kind == SourceLinkGuid
+                       let bl =  _reader.GetBlobBytes(cd.Value)
+                       select Encoding.UTF8.GetString(bl))
+                .FirstOrDefault();
+
+            var jobj = JObject.Parse(sl);
+            var docs = (JObject)jobj["documents"];
+
+
+            var slis = (from prop in docs.Properties()
+                       select new SourceLinkMap
+                       {
+                           Base = prop.Name,
+                           Location = prop.Value.Value<string>()
+                       })
+                .ToList();
+
+            return slis;
+        }
+
+
+        private IReadOnlyList<AssemblyDebugSourceDocument> GetSourceDocuments()
         {
             var docs = (from docHandle in _reader.Documents
-                       let document = _reader.GetDocument(docHandle)
-                       select new AssemblyDebugData
-                       (
-                           _reader.GetString(document.Name),
-                           _reader.GetBlobBytes(document.Hash),
-                           _reader.GetGuid(document.Language),
-                           _reader.GetGuid(document.HashAlgorithm)
-                       )).ToList();
-            
+                        let document = _reader.GetDocument(docHandle)
+                        select new AssemblyDebugSourceDocument
+                        (
+                            _reader.GetString(document.Name),
+                            _reader.GetBlobBytes(document.Hash),
+                            _reader.GetGuid(document.Language),
+                            _reader.GetGuid(document.HashAlgorithm)
+                        )).ToList();
+
             return docs;
         }
 

--- a/Core/AssemblyMetadata/AssemblyDebugParser.cs
+++ b/Core/AssemblyMetadata/AssemblyDebugParser.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Metadata;
+
+namespace NuGetPe.AssemblyMetadata
+{
+    internal sealed class AssemblyDebugParser : IDisposable
+    {
+
+        public AssemblyDebugParser(MetadataReaderProvider readerProvider)
+        {
+            _readerProvider = readerProvider;
+            _reader = _readerProvider.GetMetadataReader();
+        }
+
+        private bool _disposedValue = false;
+        private readonly MetadataReaderProvider _readerProvider;
+        private readonly MetadataReader _reader;
+
+
+        public IReadOnlyList<AssemblyDebugData> GetDebugData()
+        {
+            var docs = (from docHandle in _reader.Documents
+                       let document = _reader.GetDocument(docHandle)
+                       select new AssemblyDebugData
+                       (
+                           _reader.GetString(document.Name),
+                           _reader.GetBlobBytes(document.Hash),
+                           _reader.GetGuid(document.Language),
+                           _reader.GetGuid(document.HashAlgorithm)
+                       )).ToList();
+            
+            return docs;
+        }
+
+
+        public void Dispose()
+        {
+            if (!_disposedValue)
+            {
+                _readerProvider.Dispose();
+                _disposedValue = true;
+            }
+        }
+    }
+}

--- a/Core/AssemblyMetadata/AssemblyDebugSourceDocument.cs
+++ b/Core/AssemblyMetadata/AssemblyDebugSourceDocument.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Security.Cryptography;
 
@@ -48,8 +49,11 @@ namespace NuGetPe.AssemblyMetadata
 
     public enum SymbolLanguage
     {
+        [Description("C#")]
         CSharp,
+        [Description("VB")]
         VisualBasic,
+        [Description("F#")]
         FSharp
     }
 }

--- a/Core/AssemblyMetadata/AssemblyDebugSourceDocument.cs
+++ b/Core/AssemblyMetadata/AssemblyDebugSourceDocument.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Diagnostics;
+using System.Security.Cryptography;
+
+namespace NuGetPe.AssemblyMetadata
+{
+    [DebuggerDisplay("{Name}")]
+    public class AssemblyDebugSourceDocument
+    {
+        private static readonly Guid CSharp = new Guid("3f5162f8-07c6-11d3-9053-00c04fa302a1");
+        private static readonly Guid VisualBasic = new Guid("3a12d0b8-c26c-11d0-b442-00a0244a1dd2");
+        private static readonly Guid FSharp = new Guid("ab4f38c9-b6e6-43ba-be3b-58080b2ccce3");
+
+        private static readonly Guid Sha1 = new Guid("ff1816ec-aa5e-4d10-87f7-6f4963833460");
+        private static readonly Guid Sha256 = new Guid("8829d00f-11b8-4213-878b-770e8597ac16");
+
+        internal AssemblyDebugSourceDocument(string name, byte[] hash, Guid language, Guid hashAlgorithm)
+        {
+            Name = name;
+            Hash = hash;
+            Language = LanguageFromGuid(language);
+            HashAlgorithm = HashAlgorithmNameFromGuid(hashAlgorithm);
+        }
+
+        public string Name { get; }
+        public byte[] Hash { get; }
+        public SymbolLanguage Language { get; }
+        public HashAlgorithmName HashAlgorithm { get; }
+
+        private SymbolLanguage LanguageFromGuid(Guid guid)
+        {
+            if (guid == CSharp) return SymbolLanguage.CSharp;
+            if (guid == VisualBasic) return SymbolLanguage.VisualBasic;
+            if (guid == FSharp) return SymbolLanguage.FSharp;
+
+            throw new ArgumentOutOfRangeException(nameof(guid));
+        }
+
+
+        public HashAlgorithmName HashAlgorithmNameFromGuid(Guid guid)
+        {
+            if (guid == Sha1) return HashAlgorithmName.SHA1;
+            if (guid == Sha256) return HashAlgorithmName.SHA256;
+
+            throw new ArgumentOutOfRangeException(nameof(guid));
+        }
+    }
+
+    public enum SymbolLanguage
+    {
+        CSharp,
+        VisualBasic,
+        FSharp
+    }
+}

--- a/Core/AssemblyMetadata/AssemblyMetaData.cs
+++ b/Core/AssemblyMetadata/AssemblyMetaData.cs
@@ -14,7 +14,7 @@ namespace NuGetPe.AssemblyMetadata
         private string FullName { get; set; }
         private string StrongName { get; set; }
         private IEnumerable<AssemblyName> ReferencedAsseblies { get; set; }
-        public IReadOnlyList<AssemblyDebugData> DebugData { get; internal set; }
+        public AssemblyDebugData DebugData { get; internal set; }
 
         /// <summary>
         /// Set Fullname of the assembly and determine strong name.

--- a/Core/AssemblyMetadata/AssemblyMetaData.cs
+++ b/Core/AssemblyMetadata/AssemblyMetaData.cs
@@ -14,6 +14,7 @@ namespace NuGetPe.AssemblyMetadata
         private string FullName { get; set; }
         private string StrongName { get; set; }
         private IEnumerable<AssemblyName> ReferencedAsseblies { get; set; }
+        public IReadOnlyList<AssemblyDebugData> DebugData { get; internal set; }
 
         /// <summary>
         /// Set Fullname of the assembly and determine strong name.

--- a/Core/AssemblyMetadata/AssemblyMetadataParser.cs
+++ b/Core/AssemblyMetadata/AssemblyMetadataParser.cs
@@ -24,12 +24,12 @@ namespace NuGetPe.AssemblyMetadata
             _metadataReader = _peReader.GetMetadataReader();
         }
 
-        public IReadOnlyList<AssemblyDebugData> GetDebugData()
+        public AssemblyDebugData GetDebugData()
         {
             var entry = _peReader.ReadDebugDirectory().Where(de => de.Type == DebugDirectoryEntryType.EmbeddedPortablePdb).ToList();
             if (entry.Count == 0) // no embedded ppdb
             {
-                return new List<AssemblyDebugData>();
+                return null;
             }
             
             using (var reader = new AssemblyDebugParser(_peReader.ReadEmbeddedPortablePdbDebugDirectoryData(entry[0])))

--- a/Core/AssemblyMetadata/AssemblyMetadataParser.cs
+++ b/Core/AssemblyMetadata/AssemblyMetadataParser.cs
@@ -32,7 +32,7 @@ namespace NuGetPe.AssemblyMetadata
                 return null;
             }
             
-            using (var reader = new AssemblyDebugParser(_peReader.ReadEmbeddedPortablePdbDebugDirectoryData(entry[0])))
+            using (var reader = new AssemblyDebugParser(_peReader.ReadEmbeddedPortablePdbDebugDirectoryData(entry[0]), PdbType.Embedded))
             {
                 return reader.GetDebugData();
             }

--- a/Core/AssemblyMetadata/AssemblyMetadataParser.cs
+++ b/Core/AssemblyMetadata/AssemblyMetadataParser.cs
@@ -24,6 +24,20 @@ namespace NuGetPe.AssemblyMetadata
             _metadataReader = _peReader.GetMetadataReader();
         }
 
+        public IReadOnlyList<AssemblyDebugData> GetDebugData()
+        {
+            var entry = _peReader.ReadDebugDirectory().Where(de => de.Type == DebugDirectoryEntryType.EmbeddedPortablePdb).ToList();
+            if (entry.Count == 0) // no embedded ppdb
+            {
+                return new List<AssemblyDebugData>();
+            }
+            
+            using (var reader = new AssemblyDebugParser(_peReader.ReadEmbeddedPortablePdbDebugDirectoryData(entry[0])))
+            {
+                return reader.GetDebugData();
+            }
+        }
+
         public IEnumerable<AssemblyName> GetReferencedAssemblyNames()
         {
             foreach (var referenceHandle in _metadataReader.AssemblyReferences)

--- a/Core/AssemblyMetadata/AssemblyMetadataReader.cs
+++ b/Core/AssemblyMetadata/AssemblyMetadataReader.cs
@@ -39,6 +39,7 @@ namespace NuGetPe.AssemblyMetadata
                 {
                     AddAssemblyAttributes(metadataParser, result);
                     AddReferencedAssemblyInfo(metadataParser, result);
+                    result.DebugData = metadataParser.GetDebugData();
                 }
             }
             catch

--- a/Core/AssemblyMetadata/AssemblyMetadataReader.cs
+++ b/Core/AssemblyMetadata/AssemblyMetadataReader.cs
@@ -52,8 +52,7 @@ namespace NuGetPe.AssemblyMetadata
 
         public static AssemblyDebugData ReadDebugData(Stream debugStream)
         {
-
-            using (var reader = new AssemblyDebugParser(MetadataReaderProvider.FromPortablePdbStream(debugStream)))
+            using (var reader = new AssemblyDebugParser(MetadataReaderProvider.FromPortablePdbStream(debugStream), PdbType.Portable))
             {
                 return reader.GetDebugData();
             }

--- a/Core/AssemblyMetadata/AssemblyMetadataReader.cs
+++ b/Core/AssemblyMetadata/AssemblyMetadataReader.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Metadata;
 using System.Runtime.CompilerServices;
 
 namespace NuGetPe.AssemblyMetadata
@@ -44,6 +47,15 @@ namespace NuGetPe.AssemblyMetadata
             }
 
             return result;
+        }
+
+        public static IReadOnlyList<AssemblyDebugData> ReadDebugData(Stream debugStream)
+        {
+
+            using (var reader = new AssemblyDebugParser(MetadataReaderProvider.FromPortablePdbStream(debugStream)))
+            {
+                return reader.GetDebugData();
+            }
         }
 
         private static void AddAssemblyAttributes(AssemblyMetadataParser parser, AssemblyMetaData result)

--- a/Core/AssemblyMetadata/AssemblyMetadataReader.cs
+++ b/Core/AssemblyMetadata/AssemblyMetadataReader.cs
@@ -50,7 +50,7 @@ namespace NuGetPe.AssemblyMetadata
             return result;
         }
 
-        public static IReadOnlyList<AssemblyDebugData> ReadDebugData(Stream debugStream)
+        public static AssemblyDebugData ReadDebugData(Stream debugStream)
         {
 
             using (var reader = new AssemblyDebugParser(MetadataReaderProvider.FromPortablePdbStream(debugStream)))

--- a/Core/AssemblyMetadata/SourceLinkMap.cs
+++ b/Core/AssemblyMetadata/SourceLinkMap.cs
@@ -1,0 +1,12 @@
+﻿using System.Diagnostics;
+
+namespace NuGetPe.AssemblyMetadata
+{
+    [DebuggerDisplay("{Base} => {Location}")]
+    public class SourceLinkMap
+    {
+        public string Base { get; internal set; }
+
+        public string Location { get; internal set; }
+    }
+}

--- a/PackageExplorer/App.xaml
+++ b/PackageExplorer/App.xaml
@@ -18,6 +18,7 @@
             <self:BooleanToVisibilityConverter x:Key="boolToVis" />
             <self:CountToVisibilityConverter x:Key="countConverter" />
             <self:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
+            <self:NullToVisibilityConverter x:Key="InvertedNullToVisibilityConverter" Inverted="True" />
             <self:NullToBoolConverter x:Key="nullToBoolConverter" />
             <self:AndLogicConverter x:Key="andConverter" />
             <self:SubtracterConverter x:Key="SubtracterConverter" />
@@ -28,6 +29,7 @@
             <self:CertificateToSubjectConverter x:Key="CertificateToSubjectConverter" />
             <self:IconUrlToImageCacheConverter x:Key="IconUrlToImageCacheConverter" />
             <self:NumberToStringConverter x:Key="NumberToStringConverter" />
+            <self:EnumConverter x:Key="EnumConverter" />
 
             <ContextMenu x:Key="TextBoxContextMenu">
                 <self:GrayscaleMenuItem Command="Cut">

--- a/PackageExplorer/ContentViewerPane.xaml
+++ b/PackageExplorer/ContentViewerPane.xaml
@@ -15,7 +15,13 @@
 		</Grid.RowDefinitions>
 
 		<!-- for binary file -->
-		<ScrollViewer Grid.Row="2" Visibility="{Binding IsTextFile, Converter={StaticResource invertedBoolToVis}}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Padding="4,5,4,2" Content="{Binding Content}"></ScrollViewer>
+        <ContentControl Grid.Row="2"
+                        Visibility="{Binding IsTextFile, Converter={StaticResource invertedBoolToVis}}"
+                        VerticalAlignment="Stretch"
+                        HorizontalAlignment="Stretch"
+                        Padding="4,5,4,2"
+                        Content="{Binding Content}"
+                        />
 
 		<!-- for built-in text file -->
 		

--- a/PackageExplorer/Controls/PdbFileViewer.xaml
+++ b/PackageExplorer/Controls/PdbFileViewer.xaml
@@ -7,7 +7,7 @@
              xmlns:packageExplorerViewModel="clr-namespace:PackageExplorerViewModel;assembly=PackageViewModel"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
-    <Grid Margin="5">
+    <Grid Margin="3">
         <ItemsControl ItemsSource="{Binding Sources}">
             <ItemsControl.ItemTemplate>
                 <DataTemplate DataType="{x:Type packageExplorerViewModel:AssemblyDebugDataViewModel}">

--- a/PackageExplorer/Controls/PdbFileViewer.xaml
+++ b/PackageExplorer/Controls/PdbFileViewer.xaml
@@ -1,0 +1,31 @@
+﻿<UserControl x:Class="PackageExplorer.Controls.PdbFileViewer"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:PackageExplorer.Controls"
+             xmlns:packageExplorerViewModel="clr-namespace:PackageExplorerViewModel;assembly=PackageViewModel"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid Margin="5">
+        <ItemsControl ItemsSource="{Binding Sources}">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate DataType="{x:Type packageExplorerViewModel:AssemblyDebugDataViewModel}">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="{Binding Language, Converter={StaticResource EnumConverter}, Mode=OneWay}"  />
+                        <TextBlock Text="{Binding Path, Mode=OneWay}" Grid.Column="1" Margin="5,0,0,0" Visibility="{Binding Location, Converter={StaticResource InvertedNullToVisibilityConverter}, Mode=OneWay}" />
+                        <TextBlock Grid.Column="1" Margin="5,0,0,0" Visibility="{Binding Location, Converter={StaticResource NullToVisibilityConverter}, Mode=OneWay}">
+                            <Hyperlink Command="GoToPage" CommandParameter="{Binding Location, Mode=OneWay}"><Run Text="{Binding Location, Mode=OneWay}" /></Hyperlink>
+                        </TextBlock>
+                    </Grid>
+
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+
+        </ItemsControl>
+    </Grid>
+</UserControl>

--- a/PackageExplorer/Controls/PdbFileViewer.xaml.cs
+++ b/PackageExplorer/Controls/PdbFileViewer.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace PackageExplorer.Controls
+{
+    /// <summary>
+    /// Interaction logic for PdbFileViewer.xaml
+    /// </summary>
+    public partial class PdbFileViewer : UserControl
+    {
+        public PdbFileViewer()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/PackageExplorer/Converters/EnumConverter.cs
+++ b/PackageExplorer/Converters/EnumConverter.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Data;
+
+namespace PackageExplorer
+{
+    public class EnumConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value == null) return DependencyProperty.UnsetValue;
+
+            return GetDescription((Enum)value);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return value;
+        }
+
+        public static string GetDescription(Enum en)
+        {
+            var type = en.GetType();
+            var memInfo = type.GetMember(en.ToString());
+            if (memInfo != null && memInfo.Length > 0)
+            {
+                var attrs = memInfo[0].GetCustomAttributes(typeof(DescriptionAttribute), false);
+                if (attrs != null && attrs.Length > 0)
+                {
+                    return ((DescriptionAttribute)attrs[0]).Description;
+                }
+            }
+            return en.ToString();
+        }
+    }
+}

--- a/PackageExplorer/MefServices/AssemblyFileViewer.cs
+++ b/PackageExplorer/MefServices/AssemblyFileViewer.cs
@@ -34,7 +34,14 @@ namespace PackageExplorer
                 {
                     var orderedAssemblyDataEntries = assemblyMetadata.GetMetadataEntriesOrderedByImportance();
 
-                    return CreateAssemblyMetadataGrid(orderedAssemblyDataEntries);
+                    var grid = CreateAssemblyMetadataGrid(orderedAssemblyDataEntries);
+
+                    return new ScrollViewer
+                    {
+                        HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
+                        VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                        Content = grid,
+                    };
                 }
                 else if (assemblyMetadata != null && debugDataViewModel != null)
                 {
@@ -48,14 +55,24 @@ namespace PackageExplorer
                             new TabItem
                             {
                                 Header = "Assembly Attributes",
-                                Content = CreateAssemblyMetadataGrid(orderedAssemblyDataEntries)
+                                Content = new ScrollViewer()
+                                {
+                                    HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
+                                    VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                                    Content = CreateAssemblyMetadataGrid(orderedAssemblyDataEntries)
+                                }
                             },
                             new TabItem
                             {
                                 Header = "Embedded PDB Data",
-                                Content = new Controls.PdbFileViewer
+                                Content = new ScrollViewer
                                 {
-                                    DataContext = debugDataViewModel
+                                    HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
+                                    VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                                    Content = new Controls.PdbFileViewer
+                                    {
+                                        DataContext = debugDataViewModel
+                                    }
                                 }
                             }
                         }

--- a/PackageExplorer/MefServices/AssemblyFileViewer.cs
+++ b/PackageExplorer/MefServices/AssemblyFileViewer.cs
@@ -1,23 +1,21 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 using NuGetPackageExplorer.Types;
 using NuGetPe.AssemblyMetadata;
+using PackageExplorerViewModel;
 
 namespace PackageExplorer
 {
     [PackageContentViewerMetadata(100, ".dll", ".exe", ".winmd", SupportsWindows10S = false)]
     internal class AssemblyFileViewer : IPackageContentViewer
     {
-        #region IPackageContentViewer Members
-
+        
         public object GetView(string extension, Stream stream)
         {
             var tempFile = Path.GetTempFileName();
 
-            var grid = new Grid();
-            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) });
-            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) });
 
             try
             {
@@ -27,35 +25,43 @@ namespace PackageExplorer
                 }
 
                 var assemblyMetadata = AssemblyMetadataReader.ReadMetaData(tempFile);
+                AssemblyDebugDataViewModel debugDataViewModel = null;
+                if (assemblyMetadata.DebugData != null)
+                    debugDataViewModel = new AssemblyDebugDataViewModel(assemblyMetadata.DebugData);
 
-
-                if (assemblyMetadata != null)
+                // No debug data to display
+                if (assemblyMetadata != null && debugDataViewModel == null)
                 {
                     var orderedAssemblyDataEntries = assemblyMetadata.GetMetadataEntriesOrderedByImportance();
 
-                    foreach (var data in orderedAssemblyDataEntries)
+                    return CreateAssemblyMetadataGrid(orderedAssemblyDataEntries);
+                }
+                else if (assemblyMetadata != null && debugDataViewModel != null)
+                {
+                    var orderedAssemblyDataEntries = assemblyMetadata.GetMetadataEntriesOrderedByImportance();
+
+                    // Tab control with two pages
+                    var tc = new TabControl()
                     {
-                        var label = new TextBlock
+                        Items =
                         {
-                            Text = data.Key + ':',
-                            FontWeight = FontWeights.SemiBold,
-                            Margin = new Thickness(3, 3, 10, 0)
-                        };
-                        Grid.SetRow(label, grid.RowDefinitions.Count);
-                        Grid.SetColumn(label, 0);
+                            new TabItem
+                            {
+                                Header = "Assembly Attributes",
+                                Content = CreateAssemblyMetadataGrid(orderedAssemblyDataEntries)
+                            },
+                            new TabItem
+                            {
+                                Header = "Embedded PDB Data",
+                                Content = new Controls.PdbFileViewer
+                                {
+                                    DataContext = debugDataViewModel
+                                }
+                            }
+                        }
+                    };
 
-                        var value = new TextBlock
-                        {
-                            Text = data.Value,
-                            Margin = new Thickness(0, 3, 3, 0)
-                        };
-                        Grid.SetRow(value, grid.RowDefinitions.Count);
-                        Grid.SetColumn(value, 1);
-
-                        grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) });
-                        grid.Children.Add(label);
-                        grid.Children.Add(value);
-                    }
+                    return tc;
                 }
             }
             catch { }
@@ -73,9 +79,42 @@ namespace PackageExplorer
                 }
             }
 
-            return grid;
+            return new Grid();
         }
 
-        #endregion
+
+        private static Grid CreateAssemblyMetadataGrid(IEnumerable<KeyValuePair<string, string>> orderedAssemblyDataEntries)
+        {
+
+            var grid = new Grid();
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) });
+
+            foreach (var data in orderedAssemblyDataEntries)
+            {
+                var label = new TextBlock
+                {
+                    Text = data.Key + ':',
+                    FontWeight = FontWeights.SemiBold,
+                    Margin = new Thickness(3, 3, 10, 0)
+                };
+                Grid.SetRow(label, grid.RowDefinitions.Count);
+                Grid.SetColumn(label, 0);
+
+                var value = new TextBlock
+                {
+                    Text = data.Value,
+                    Margin = new Thickness(0, 3, 3, 0)
+                };
+                Grid.SetRow(value, grid.RowDefinitions.Count);
+                Grid.SetColumn(value, 1);
+
+                grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) });
+                grid.Children.Add(label);
+                grid.Children.Add(value);
+            }
+
+            return grid;
+        }
     }
 }

--- a/PackageExplorer/MefServices/ImageFileViewer.cs
+++ b/PackageExplorer/MefServices/ImageFileViewer.cs
@@ -20,11 +20,19 @@ namespace PackageExplorer
             source.StreamSource = stream;
             source.EndInit();
 
-            return new Image
+            var image = new Image
             {
                 Source = source,
                 Width = source.Width,
-                Height = source.Height
+                Height = source.Height,
+                
+            };
+
+            return new ScrollViewer
+            {
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                Content = image
             };
         }
 

--- a/PackageExplorer/MefServices/PdbFileViewer.cs
+++ b/PackageExplorer/MefServices/PdbFileViewer.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Controls;
 using NuGetPackageExplorer.Types;
 using NuGetPe.AssemblyMetadata;
@@ -17,21 +18,33 @@ namespace PackageExplorer
         public object GetView(string extension, Stream stream)
         {
             AssemblyDebugDataViewModel data = null;
-            using (var str = StreamUtility.MakeSeekable(stream))
-            {
-                data = new AssemblyDebugDataViewModel(AssemblyMetadataReader.ReadDebugData(str));
-            }
 
-
-            return new ScrollViewer
+            try
             {
-                HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
-                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
-                Content = new Controls.PdbFileViewer
+                using (var str = StreamUtility.MakeSeekable(stream))
                 {
-                    DataContext = data
+                    data = new AssemblyDebugDataViewModel(AssemblyMetadataReader.ReadDebugData(str));
                 }
-            };
+
+                return new ScrollViewer
+                {
+                    HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
+                    VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                    Content = new Controls.PdbFileViewer
+                    {
+                        DataContext = data
+                    }
+                };
+            }
+            catch 
+            {
+                return new TextBlock()
+                {
+                    Text = "Full PDB's are not supported yet. Portable and Embedded are currently supported.",
+                    Margin = new Thickness(3)
+                };
+            }
+            
         }
     }
 }

--- a/PackageExplorer/MefServices/PdbFileViewer.cs
+++ b/PackageExplorer/MefServices/PdbFileViewer.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+using NuGetPackageExplorer.Types;
+using NuGetPe.AssemblyMetadata;
+
+namespace PackageExplorer
+{
+    [PackageContentViewerMetadata(100, ".pdb", SupportsWindows10S = false)]
+    class PdbFileViewer : IPackageContentViewer
+    {
+        public object GetView(string extension, Stream stream)
+        {
+            using (var str = StreamUtility.MakeSeekable(stream))
+            {
+                var doc = AssemblyMetadataReader.ReadDebugData(str);
+            }
+
+            return new TextBlock() { Text = "PdbViewer" };
+        }
+    }
+}

--- a/PackageExplorer/MefServices/PdbFileViewer.cs
+++ b/PackageExplorer/MefServices/PdbFileViewer.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Windows.Controls;
 using NuGetPackageExplorer.Types;
 using NuGetPe.AssemblyMetadata;
+using PackageExplorerViewModel;
 
 namespace PackageExplorer
 {
@@ -15,12 +16,16 @@ namespace PackageExplorer
     {
         public object GetView(string extension, Stream stream)
         {
+            AssemblyDebugDataViewModel data = null;
             using (var str = StreamUtility.MakeSeekable(stream))
             {
-                var doc = AssemblyMetadataReader.ReadDebugData(str);
+                data = new AssemblyDebugDataViewModel(AssemblyMetadataReader.ReadDebugData(str));
             }
 
-            return new TextBlock() { Text = "PdbViewer" };
+            return new Controls.PdbFileViewer
+            {
+                DataContext = data
+            };
         }
     }
 }

--- a/PackageExplorer/MefServices/PdbFileViewer.cs
+++ b/PackageExplorer/MefServices/PdbFileViewer.cs
@@ -22,9 +22,15 @@ namespace PackageExplorer
                 data = new AssemblyDebugDataViewModel(AssemblyMetadataReader.ReadDebugData(str));
             }
 
-            return new Controls.PdbFileViewer
+
+            return new ScrollViewer
             {
-                DataContext = data
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                Content = new Controls.PdbFileViewer
+                {
+                    DataContext = data
+                }
             };
         }
     }

--- a/PackageExplorer/MefServices/RtfFileViewer.cs
+++ b/PackageExplorer/MefServices/RtfFileViewer.cs
@@ -20,7 +20,9 @@ namespace PackageExplorer
             var rtf = new RichTextBox
             {
                 IsReadOnly = true,
-                BorderThickness = new System.Windows.Thickness(0)
+                BorderThickness = new System.Windows.Thickness(0),
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Auto
             };
             rtf.Document.MinPageWidth = 800;
 

--- a/PackageViewModel/AssemblyDebugDataViewModel.cs
+++ b/PackageViewModel/AssemblyDebugDataViewModel.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NuGetPe.AssemblyMetadata;
+
+namespace PackageExplorerViewModel
+{
+    public class AssemblyDebugDataViewModel
+    {
+        private readonly AssemblyDebugData _debugData;
+
+        public AssemblyDebugDataViewModel(AssemblyDebugData debugData)
+        {
+            _debugData = debugData ?? throw new ArgumentNullException(nameof(debugData));
+            Sources = CreateSourcesViewModels(debugData);
+        }
+
+        public PdbType PdbType => _debugData.PdbType;
+
+        public IReadOnlyList<AssemblyDebugSourceDocumentViewModel> Sources { get; }
+
+        private static IReadOnlyList<AssemblyDebugSourceDocumentViewModel> CreateSourcesViewModels(AssemblyDebugData debugData)
+        {
+            var list = new List<AssemblyDebugSourceDocumentViewModel>(debugData.Sources.Count);
+
+            var lookup = debugData.SourceLink.ToDictionary(sm => sm.Base.Substring(0, sm.Base.Length-1), sm => sm.Location.Substring(0, sm.Location.Length-1));
+
+            foreach (var doc in debugData.Sources)
+            {
+                var path = doc.Name;
+                string location = null;
+                // see if any keys match the base
+                foreach (var key in lookup.Keys)
+                {
+                    if (doc.Name.StartsWith(key, StringComparison.Ordinal))
+                    {
+                        path = doc.Name.Substring(key.Length);
+                        location = lookup[key] + path;
+
+                        break;
+                    }
+                }
+
+                list.Add(new AssemblyDebugSourceDocumentViewModel(doc, path, location));
+            }
+
+            return list;
+        }
+
+    }
+}

--- a/PackageViewModel/AssemblyDebugSourceDocumentViewModel.cs
+++ b/PackageViewModel/AssemblyDebugSourceDocumentViewModel.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NuGetPe.AssemblyMetadata;
+
+namespace PackageExplorerViewModel
+{
+    public class AssemblyDebugSourceDocumentViewModel
+    {
+        private readonly AssemblyDebugSourceDocument _sourceDocument;
+
+        public AssemblyDebugSourceDocumentViewModel(AssemblyDebugSourceDocument sourceDocument, string path, string location)
+        {
+            _sourceDocument = sourceDocument ?? throw new ArgumentNullException(nameof(sourceDocument));
+            Path = path;
+            Location = location;
+        }
+
+        public string Path { get; }
+        public string Location { get; }
+
+        public string HashAlgorithm => _sourceDocument.HashAlgorithm.Name;
+
+        public SymbolLanguage Language => _sourceDocument.Language;
+    }
+}


### PR DESCRIPTION
This fixes #496 and #502 

Displays the linked source information for ppdb and embedded pdb's.

Data is currently extracted.

To Do:

- [x] Create UX for displaying data
- [x] Add UX to dll viewer
- [ ] Test with non-sourcelinked ppdb
- [x] Test with Full PDB