### PR TITLE
Avoid certain code paths on Windows 7

### DIFF
--- a/Core/Repositories/MachineCache.cs
+++ b/Core/Repositories/MachineCache.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Security;
 using Windows.Storage;
 using NuGet.Versioning;
@@ -131,18 +132,28 @@ namespace NuGetPe
         private static string GetCachePath()
         {
             // Try getting it from the app model first
-            try
+            if (AppContainerUtility.IsInAppContainer)
             {
-                // Get the localized special folder for local app data
-                var local = new DirectoryInfo(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)).Name;
-                return GetCachePath(Environment.GetEnvironmentVariable, _ => Path.Combine(ApplicationData.Current.LocalCacheFolder.Path, local));
-            }
-            catch
-            { 
-                // Don't care here, not on Win7 or running in an app model context
+                try
+                {
+                    return GetCachePathFromLocalCache();
+                }
+                catch
+                {
+                    // Don't care here, not on Win7 or running in an app model context
+                }
             }
 
             return GetCachePath(Environment.GetEnvironmentVariable, Environment.GetFolderPath);
+        }
+
+        // Don't load these types inline
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static string GetCachePathFromLocalCache()
+        {
+            // Get the localized special folder for local app data
+            var local = new DirectoryInfo(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)).Name;
+            return GetCachePath(Environment.GetEnvironmentVariable, _ => Path.Combine(ApplicationData.Current.LocalCacheFolder.Path, local));
         }
 
         private static string GetCachePath(Func<string, string> getEnvironmentVariable, Func<Environment.SpecialFolder, string> getFolderPath)

--- a/Core/Utility/AppContainerUtility.cs
+++ b/Core/Utility/AppContainerUtility.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Storage;
+using Microsoft.Toolkit.Win32.UI.Controls.Interop;
+
+namespace NuGetPe
+{
+    public static class AppContainerUtility
+    {
+        
+        public static bool IsInAppContainer { get; } = OSVersionHelper.IsWindows10 && HasPackageIdentity();
+
+        // Don't load types from here accidently
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static bool HasPackageIdentity()
+        {
+            try
+            {
+                var container = ApplicationData.Current.LocalSettings;
+                return true;
+            }
+            catch
+            {
+            }
+            return false;
+        }
+    }
+}

--- a/Core/Utility/Toolkit/ExternDll.cs
+++ b/Core/Utility/Toolkit/ExternDll.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Toolkit.Win32.UI.Controls.Interop.Win32
+{
+    internal static class ExternDll
+    {
+        internal const string Kernel32 = "kernel32.dll";
+        internal const string User32 = "user32.dll";
+        internal const string Ntdll = "ntdll.dll";
+        internal const string Gdi32 = "gdi32.dll";
+        internal const string EdgeHtml = "edgehtml.dll";
+        internal const string ShCore = "shcore.dll";
+    }
+}

--- a/Core/Utility/Toolkit/Facility.cs
+++ b/Core/Utility/Toolkit/Facility.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Toolkit.Win32.UI.Controls.Interop.Win32
+{
+    internal enum Facility
+    {
+        /// <summary>FACILITY_NULL</summary>
+        Null = 0,
+
+        /// <summary>FACILITY_RPC</summary>
+        Rpc = 1,
+
+        /// <summary>FACILITY_DISPATCH</summary>
+        Dispatch = 2,
+
+        /// <summary>FACILITY_STORAGE</summary>
+        Storage = 3,
+
+        /// <summary>FACILITY_ITF</summary>
+        Itf = 4,
+
+        /// <summary>FACILITY_WIN32</summary>
+        Win32 = 7,
+
+        /// <summary>FACILITY_WINDOWS</summary>
+        Windows = 8,
+
+        /// <summary>FACILITY_CONTROL</summary>
+        Control = 10,
+
+        /// <summary>MSDN doced facility code for ESE errors.</summary>
+        Ese = 0xE5E,
+
+        /// <summary>FACILITY_WINCODEC (WIC)</summary>
+        WinCodec = 0x898,
+    }
+}

--- a/Core/Utility/Toolkit/HRESULT.cs
+++ b/Core/Utility/Toolkit/HRESULT.cs
@@ -1,0 +1,359 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace Microsoft.Toolkit.Win32.UI.Controls.Interop.Win32
+{
+    /// <summary>Wrapper for HRESULT status codes.</summary>
+    [StructLayout(LayoutKind.Explicit)]
+    internal struct HRESULT
+    {
+        [FieldOffset(0)]
+        private readonly uint _value;
+
+        // NOTE: These public static field declarations are automatically
+        // picked up by ToString through reflection.
+
+        /// <summary>S_OK</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May only be used in DEBUG builds")]
+        public static readonly HRESULT S_OK = new HRESULT(0x00000000);
+
+        /// <summary>S_FALSE</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May only be used in DEBUG builds")]
+        public static readonly HRESULT S_FALSE = new HRESULT(0x00000001);
+
+        /// <summary>E_PENDING</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May only be used in DEBUG builds")]
+        public static readonly HRESULT E_PENDING = new HRESULT(0x8000000A);
+
+        /// <summary>E_NOTIMPL</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May only be used in DEBUG builds")]
+        public static readonly HRESULT E_NOTIMPL = new HRESULT(0x80004001);
+
+        /// <summary>E_NOINTERFACE</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May only be used in DEBUG builds")]
+        public static readonly HRESULT E_NOINTERFACE = new HRESULT(0x80004002);
+
+        /// <summary>E_POINTER</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May only be used in DEBUG builds")]
+        public static readonly HRESULT E_POINTER = new HRESULT(0x80004003);
+
+        /// <summary>E_ABORT</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May only be used in DEBUG builds")]
+        public static readonly HRESULT E_ABORT = new HRESULT(0x80004004);
+
+        /// <summary>E_FAIL</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May only be used in DEBUG builds")]
+        public static readonly HRESULT E_FAIL = new HRESULT(0x80004005);
+
+        /// <summary>E_UNEXPECTED</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May only be used in DEBUG builds")]
+        public static readonly HRESULT E_UNEXPECTED = new HRESULT(0x8000FFFF);
+
+        /// <summary>STG_E_INVALIDFUNCTION</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May only be used in DEBUG builds")]
+        public static readonly HRESULT STG_E_INVALIDFUNCTION = new HRESULT(0x80030001);
+
+        /// <summary>REGDB_E_CLASSNOTREG</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May only be used in DEBUG builds")]
+        public static readonly HRESULT REGDB_E_CLASSNOTREG = new HRESULT(0x80040154);
+
+        /// <summary>DESTS_E_NO_MATCHING_ASSOC_HANDLER.  Win7 internal error code for Jump Lists.</summary>
+        /// <remarks>There is no Assoc Handler for the given item registered by the specified application.</remarks>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May only be used in DEBUG builds")]
+        public static readonly HRESULT DESTS_E_NO_MATCHING_ASSOC_HANDLER = new HRESULT(0x80040F03);
+
+        /// <summary>DESTS_E_NORECDOCS.  Win7 internal error code for Jump Lists.</summary>
+        /// <remarks>The given item is excluded from the recent docs folder by the NoRecDocs bit on its registration.</remarks>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May only be used in DEBUG builds")]
+        public static readonly HRESULT DESTS_E_NORECDOCS = new HRESULT(0x80040F04);
+
+        /// <summary>DESTS_E_NOTALLCLEARED.  Win7 internal error code for Jump Lists.</summary>
+        /// <remarks>Not all of the items were successfully cleared</remarks>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May only be used in DEBUG builds")]
+        public static readonly HRESULT DESTS_E_NOTALLCLEARED = new HRESULT(0x80040F05);
+
+        /// <summary>E_ACCESSDENIED</summary>
+        /// <remarks>Win32Error ERROR_ACCESS_DENIED.</remarks>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May only be used in DEBUG builds")]
+        public static readonly HRESULT E_ACCESSDENIED = new HRESULT(0x80070005);
+
+        /// <summary>E_OUTOFMEMORY</summary>
+        /// <remarks>Win32Error ERROR_OUTOFMEMORY.</remarks>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May only be used in DEBUG builds")]
+        public static readonly HRESULT E_OUTOFMEMORY = new HRESULT(0x8007000E);
+
+        /// <summary>E_INVALIDARG</summary>
+        /// <remarks>Win32Error ERROR_INVALID_PARAMETER.</remarks>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May only be used in DEBUG builds")]
+        public static readonly HRESULT E_INVALIDARG = new HRESULT(0x80070057);
+
+        /// <summary>INTSAFE_E_ARITHMETIC_OVERFLOW</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May only be used in DEBUG builds")]
+        public static readonly HRESULT INTSAFE_E_ARITHMETIC_OVERFLOW = new HRESULT(0x80070216);
+
+        /// <summary>COR_E_OBJECTDISPOSED</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May only be used in DEBUG builds")]
+        public static readonly HRESULT COR_E_OBJECTDISPOSED = new HRESULT(0x80131622);
+
+        /// <summary>WC_E_GREATERTHAN</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May only be used in DEBUG builds")]
+        public static readonly HRESULT WC_E_GREATERTHAN = new HRESULT(0xC00CEE23);
+
+        /// <summary>WC_E_SYNTAX</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May only be used in DEBUG builds")]
+        public static readonly HRESULT WC_E_SYNTAX = new HRESULT(0xC00CEE2D);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HRESULT"/> struct.
+        /// </summary>
+        /// <param name="i"><see cref="uint" /> containing HRESULT.</param>
+        public HRESULT(uint i)
+        {
+            _value = i;
+        }
+
+        public static HRESULT Make(bool severe, Facility facility, int code)
+        {
+            // #define MAKE_HRESULT(sev,fac,code) \
+            //    ((HRESULT) (((unsigned long)(sev)<<31) | ((unsigned long)(fac)<<16) | ((unsigned long)(code))) )
+
+            // Severity has 1 bit reserved.
+            // bitness is enforced by the boolean parameter.
+
+            // Facility has 11 bits reserved (different than SCODES, which have 4 bits reserved)
+            // MSDN documentation incorrectly uses 12 bits for the ESE facility (e5e), so go ahead and let that one slide.
+            // And WIC also ignores it the documented size...
+            Verify.Implies((int)facility != (int)((int)facility & 0x1FF), facility == Facility.Ese || facility == Facility.WinCodec);
+
+            // Code has 4 bits reserved.
+            Verify.AreEqual(code, code & 0xFFFF);
+
+            return new HRESULT((uint)((severe ? 1 << 31 : 0) | ((int)facility << 16) | code));
+        }
+
+        /// <summary>
+        /// Gets HRESULT_FACILITY
+        /// </summary>
+        public Facility Facility
+        {
+            get
+            {
+                return GetFacility((int)_value);
+            }
+        }
+
+        public static Facility GetFacility(int errorCode)
+        {
+            // #define HRESULT_FACILITY(hr)  (((hr) >> 16) & 0x1fff)
+            return (Facility)((errorCode >> 16) & 0x1fff);
+        }
+
+        /// <summary>
+        /// Gets HRESULT_CODE
+        /// </summary>
+        public int Code
+        {
+            get
+            {
+                return GetCode((int)_value);
+            }
+        }
+
+        public static int GetCode(int error)
+        {
+            // #define HRESULT_CODE(hr)    ((hr) & 0xFFFF)
+            return (int)(error & 0xFFFF);
+        }
+
+        /// <summary>
+        /// Get a string representation of this HRESULT.
+        /// </summary>
+        /// <returns>Name of HRESULT</returns>
+        public override string ToString()
+        {
+            // Use reflection to try to name this HRESULT.
+            // This is expensive, but if someone's ever printing HRESULT strings then
+            // I think it's a fair guess that they're not in a performance critical area
+            // (e.g. printing exception strings).
+            // This is less error prone than trying to keep the list in the function.
+            // To properly add an HRESULT's name to the ToString table, just add the HRESULT
+            // like all the others above.
+            //
+            // CONSIDER: This data is static.  It could be cached
+            // after first usage for fast lookup since the keys are unique.
+            foreach (var publicStaticField in typeof(HRESULT).GetFields(BindingFlags.Static | BindingFlags.Public))
+            {
+                if (publicStaticField.FieldType == typeof(HRESULT))
+                {
+                    var hr = (HRESULT)publicStaticField.GetValue(null);
+                    if (hr == this)
+                    {
+                        return publicStaticField.Name;
+                    }
+                }
+            }
+
+            // Try Win32 error codes also
+            if (Facility == Facility.Win32)
+            {
+                foreach (var publicStaticField in typeof(Win32Error).GetFields(BindingFlags.Static | BindingFlags.Public))
+                {
+                    if (publicStaticField.FieldType == typeof(Win32Error))
+                    {
+                        var error = (Win32Error)publicStaticField.GetValue(null);
+                        if ((HRESULT)error == this)
+                        {
+                            return "HRESULT_FROM_WIN32(" + publicStaticField.Name + ")";
+                        }
+                    }
+                }
+            }
+
+            // If there's no good name for this HRESULT,
+            // return the string as readable hex (0x########) format.
+            return string.Format(CultureInfo.InvariantCulture, "0x{0:X8}", _value);
+        }
+
+        public override bool Equals(object obj)
+        {
+            try
+            {
+                return ((HRESULT)obj)._value == _value;
+            }
+            catch (InvalidCastException)
+            {
+                return false;
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            return _value.GetHashCode();
+        }
+
+        public static bool operator ==(HRESULT hrLeft, HRESULT hrRight)
+        {
+            return hrLeft._value == hrRight._value;
+        }
+
+        public static bool operator !=(HRESULT hrLeft, HRESULT hrRight)
+        {
+            return !(hrLeft == hrRight);
+        }
+
+        public bool Succeeded
+        {
+            get { return (int)_value >= 0; }
+        }
+
+        public bool Failed
+        {
+            get { return (int)_value < 0; }
+        }
+
+        /// <summary>
+        /// Convert the result of Win32 GetLastError() into a raised exception.
+        /// </summary>
+        [SecurityCritical]
+        public static void ThrowLastError()
+        {
+            ((HRESULT)Win32Error.GetLastError()).ThrowIfFailed();
+
+            // Only expecting to call this when we're expecting a failed GetLastError()
+            Verify.Fail();
+        }
+
+        // Critical: P-Invoke
+        [SecurityCritical]
+        [SuppressMessage(
+                "Microsoft.Usage",
+                "CA2201:DoNotRaiseReservedExceptionTypes",
+                Justification = "Only recreating Exceptions that were already raised.")]
+        [SuppressMessage(
+                "Microsoft.Globalization",
+                "CA1303:DoNotPassLiteralsAsLocalizedParameters",
+                Justification = "For DEBUG only")]
+        public void ThrowIfFailed(string message = null)
+        {
+            if (Failed)
+            {
+                if (string.IsNullOrEmpty(message))
+                {
+                    message = ToString();
+                }
+#if DEBUG
+                else
+                {
+                    message += " (" + ToString() + ")";
+                }
+#endif
+
+                // Wow.  Reflection in a throw call.  Later on this may turn out to have been a bad idea.
+                // If you're throwing an exception I assume it's OK for me to take some time to give it back.
+                // I want to convert the HRESULT to a more appropriate exception type than COMException.
+                // Marshal.ThrowExceptionForHR does this for me, but the general call uses GetErrorInfo
+                // if it's set, and then ignores the HRESULT that I've provided.  This makes it so this
+                // call works the first time but you get burned on the second.  To avoid this, I use
+                // the overload that explicitly ignores the IErrorInfo.
+                // In addition, the function doesn't allow me to set the Message unless I go through
+                // the process of implementing an IErrorInfo and then use that.  There's no stock
+                // implementations of IErrorInfo available and I don't think it's worth the maintenance
+                // overhead of doing it, nor would it have significant value over this approach.
+                var e = NativeMethods.GetExceptionForHR((int)_value);
+                Verify.IsNotNull(e);
+
+                // ArgumentNullException doesn't have the right constructor parameters,
+                // (nor does Win32Exception...)
+                // but E_POINTER gets mapped to NullReferenceException,
+                // so I don't think it will ever matter.
+                Verify.IsFalse(e is ArgumentNullException);
+
+                // If we're not getting anything better than a COMException from Marshal,
+                // then at least check the facility and attempt to do better ourselves.
+                if (e.GetType() == typeof(COMException))
+                {
+                    switch (Facility)
+                    {
+                        case Facility.Win32:
+                            e = CreateWin32Exception(Code, message);
+                            break;
+
+                        default:
+                            e = new COMException(message, (int)_value);
+                            break;
+                    }
+                }
+                else
+                {
+                    var cons = e.GetType().GetConstructor(new[] { typeof(string) });
+                    if (cons != null)
+                    {
+                        e = cons.Invoke(new object[] { message }) as Exception;
+                        Verify.IsNotNull(e);
+                    }
+                }
+
+                throw e;
+            }
+        }
+
+        [SecuritySafeCritical]
+        [SuppressMessage(
+            "Microsoft.Security",
+            "CA2136:TransparencyAnnotationsShouldNotConflict",
+            Justification = "Calls safe overload of Win32Exception ctor that explicitly sets the error code and message.")]
+        private static Exception CreateWin32Exception(int code, string message)
+        {
+            return new Win32Exception(code, message);
+        }
+    }
+}

--- a/Core/Utility/Toolkit/NativeMethods.cs
+++ b/Core/Utility/Toolkit/NativeMethods.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace Microsoft.Toolkit.Win32.UI.Controls.Interop.Win32
+{
+    internal static class NativeMethods
+    {
+        [SecurityCritical]
+        [DllImport(ExternDll.Ntdll, SetLastError = true, EntryPoint = "RtlGetVersion")]
+        private static extern bool _RtlGetVersion(ref OSVERSIONINFOEX versionInfo);
+
+        [SecurityCritical]
+        internal static OSVERSIONINFOEX RtlGetVersion()
+        {
+            var osVersionInfo = new OSVERSIONINFOEX { OSVersionInfoSize = Marshal.SizeOf(typeof(OSVERSIONINFOEX)) };
+            _RtlGetVersion(ref osVersionInfo);
+            var err = Win32Error.GetLastError();
+            if (!err.Equals(Win32Error.ERROR_SUCCESS))
+            {
+                if (osVersionInfo.MajorVersion == 0)
+                {
+                    err.ToHRESULT().ThrowIfFailed();
+                }
+            }
+
+            return osVersionInfo;
+        }
+
+        // Critical: This calls into Marshal.GetExceptionForHR which is critical
+        //           it populates the exception object from data stored in a per thread IErrorInfo
+        //           the IErrorInfo may have security sensitive information like file paths stored in it
+        // TreatAsSafe: Uses overload of GetExceptionForHR that omits IErrorInfo information from exception message
+        [SecuritySafeCritical]
+        internal static Exception GetExceptionForHR(int hr)
+        {
+            return Marshal.GetExceptionForHR(hr, new IntPtr(-1));
+        }
+    }
+}

--- a/Core/Utility/Toolkit/OSVERSIONINFOEX.cs
+++ b/Core/Utility/Toolkit/OSVERSIONINFOEX.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Toolkit.Win32.UI.Controls.Interop.Win32
+{
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    internal struct OSVERSIONINFOEX
+    {
+        // The OSVersionInfoSize field must be set to Marshal.SizeOf(typeof(OSVERSIONINFOEX))
+        internal int OSVersionInfoSize;
+        internal int MajorVersion;
+        internal int MinorVersion;
+        internal int BuildNumber;
+        internal int PlatformId;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+        internal string CSDVersion;
+        internal ushort ServicePackMajor;
+        internal ushort ServicePackMinor;
+        internal short SuiteMask;
+        internal ProductType ProductType;
+        internal byte Reserved;
+    }
+}

--- a/Core/Utility/Toolkit/OSVersionHelper.cs
+++ b/Core/Utility/Toolkit/OSVersionHelper.cs
@@ -1,0 +1,163 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Security;
+using Microsoft.Toolkit.Win32.UI.Controls.Interop.Win32;
+using Windows.Foundation.Metadata;
+using Windows.Security.EnterpriseData;
+
+namespace Microsoft.Toolkit.Win32.UI.Controls.Interop
+{
+    internal static class OSVersionHelper
+    {
+        private const string ContractName = "Windows.Foundation.UniversalApiContract";
+
+        [SecurityCritical]
+        static OSVersionHelper()
+        {
+            if (IsSince(WindowsVersions.Win10))
+            {
+                if (IsApiContractPresent(6))
+                {
+                    Windows10Release = Windows10Release.April2018;
+                }
+                else if (IsApiContractPresent(5))
+                {
+                    Windows10Release = Windows10Release.FallCreators;
+                }
+                else if (IsApiContractPresent(4))
+                {
+                    Windows10Release = Windows10Release.Creators;
+                }
+                else if (IsApiContractPresent(3))
+                {
+                    Windows10Release = Windows10Release.Anniversary;
+                }
+                else if (IsApiContractPresent(2))
+                {
+                    Windows10Release = Windows10Release.Threshold2;
+                }
+                else if (IsApiContractPresent(1))
+                {
+                    Windows10Release = Windows10Release.Threshold1;
+                }
+                else
+                {
+                    Windows10Release = Windows10Release.Unknown;
+                }
+            }
+        }
+
+        internal static bool IsWindowsNt { get; } = Environment.OSVersion.Platform == PlatformID.Win32NT;
+
+        internal static bool IsWindows10 { get; } = IsWindowsNt && IsSince(WindowsVersions.Win10);
+
+        /// <summary>
+        /// Gets a value indicating whether the current OS is Windows 10 April 2018 Update (Redstone 4) or greater
+        /// </summary>
+        internal static bool IsWindows10April2018OrGreater => IsWindows10 && Windows10Release >= Windows10Release.April2018;
+
+        /// <summary>
+        /// Gets a value indicating whether the current OS is Windows 10 Fall Creators Update (Redstone 3) or greater
+        /// </summary>
+        internal static bool IsWindows10FallCreatorsOrGreater => IsWindows10 && Windows10Release >= Windows10Release.FallCreators;
+
+        /// <summary>
+        /// Gets a value indicating whether the current OS is Windows 10 Creators Update (Redstone 2) or greater
+        /// </summary>
+        internal static bool IsWindows10CreatorsOrGreater => IsWindows10 && Windows10Release >= Windows10Release.Creators;
+
+        /// <summary>
+        /// Gets a value indicating whether the current OS is Windows 10 Anniversary Update (Redstone 1) or greater
+        /// </summary>
+        internal static bool IsWindows10AnniversaryOrGreater => IsWindows10 && Windows10Release >= Windows10Release.Anniversary;
+
+        /// <summary>
+        /// Gets a value indicating whether the current OS is Windows 10 Threshold 2 or greater
+        /// </summary>
+        internal static bool IsWindows10Threshold2OrGreater => IsWindows10 && Windows10Release >= Windows10Release.Threshold2;
+
+        /// <summary>
+        /// Gets a value indicating whether the current OS is Windows 10 Threshold 1 or greater
+        /// </summary>
+        internal static bool IsWindows10Threshold1OrGreater => IsWindows10 && Windows10Release >= Windows10Release.Threshold1;
+
+        internal static bool IsWorkstation { get; } = !IsServer();
+
+        internal static bool UseWindowsInformationProtectionApi
+        {
+            [SecurityCritical]
+            get => Windows10Release >= Windows10Release.Anniversary && ProtectionPolicyManager.IsProtectionEnabled;
+        }
+
+        internal static Windows10Release Windows10Release { get; }
+
+
+        [SecurityCritical]
+        private static bool IsApiContractPresent(ushort majorVersion) => ApiInformation.IsApiContractPresent(ContractName, majorVersion);
+
+        [SecurityCritical]
+        private static bool IsServer()
+        {
+            var versionInfo = NativeMethods.RtlGetVersion();
+            return versionInfo.ProductType == ProductType.VER_NT_DOMAIN_CONTROLLER
+                   || versionInfo.ProductType == ProductType.VER_NT_SERVER;
+        }
+
+        [SecurityCritical]
+        internal static bool IsSince(WindowsVersions version)
+        {
+            int major;
+            int minor;
+
+            switch (version)
+            {
+                case WindowsVersions.Win7:
+                case WindowsVersions.Server2008R2:
+                    major = 6;
+                    minor = 1;
+                    break;
+
+                case WindowsVersions.Win8:
+                case WindowsVersions.Server2012:
+                    major = 6;
+                    minor = 2;
+                    break;
+
+                case WindowsVersions.Win81:
+                case WindowsVersions.Server2012R2:
+                    major = 6;
+                    minor = 3;
+                    break;
+
+                case WindowsVersions.Win10:
+                case WindowsVersions.Server2016:
+                    major = 10;
+                    minor = 0;
+                    break;
+
+                default:
+                    throw new ArgumentException("Unrecognized Operating System", nameof(version));
+            }
+
+            // After 8.1 apps without manifest or are not manifested for 8.1/10 return 6.2 when using GetVersionEx.
+            // Need to use RtlGetVersion to get correct major/minor/build
+            var os = NativeMethods.RtlGetVersion();
+
+            if (os.MajorVersion > major)
+            {
+                return true;
+            }
+
+            if (os.MajorVersion == major)
+            {
+                return os.MinorVersion >= minor;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Core/Utility/Toolkit/ProductType.cs
+++ b/Core/Utility/Toolkit/ProductType.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Toolkit.Win32.UI.Controls.Interop.Win32
+{
+    internal enum ProductType : byte
+    {
+        /// <summary>
+        /// The operating system is Windows 10, Windows 8, Windows 7, Windows Vista, Windows XP Professional, Windows XP Home Edition, or Windows 2000 Professional
+        /// </summary>
+        VER_NT_WORKSTATION = 0x0000001,
+
+        /// <summary>
+        /// The system is a domain controller and the operating system is Windows Server 2016, Windows Server 2012, Windows Server 2008 R2, Windows Server 2008, Windows Server 2003, or Windows 2000 Server
+        /// </summary>
+        VER_NT_DOMAIN_CONTROLLER = 0x0000002,
+
+        /// <summary>
+        /// The operating system is Windows Server 2016, Windows Server 2012, Windows Server 2008 R2, Windows Server 2008, Windows Server 2003, or Windows 2000 Server.
+        /// </summary>
+        /// <remarks>
+        /// Note that a server that is also a domain controller is reported as <see cref="VER_NT_DOMAIN_CONTROLLER"/>, not <see cref="VER_NT_SERVER"/>
+        /// </remarks>
+        VER_NT_SERVER = 0x0000003
+    }
+}

--- a/Core/Utility/Toolkit/Verify.cs
+++ b/Core/Utility/Toolkit/Verify.cs
@@ -1,0 +1,309 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+
+namespace Microsoft.Toolkit.Win32.UI.Controls
+{
+    [DebuggerStepThrough]
+    [DebuggerNonUserCode]
+    internal static class Verify
+    {
+        // Conditional to use more aggressive fail-fast behaviors when debugging
+#if DEV_DEBUG
+        private const bool AggressiveFailFast = true;
+#else
+        private const bool AggressiveFailFast = false;
+#endif
+
+        /// <summary>
+        /// Verifies that two generic type data are equal.  The assertion fails if they are not.
+        /// </summary>
+        /// <typeparam name="T">The generic type to compare for equality.</typeparam>
+        /// <param name="expected">The first generic type data to compare.  This is is the expected value.</param>
+        /// <param name="actual">The second generic type data to compare.  This is the actual value.</param>
+        /// <remarks>This breaks into the debugger in the case of a failed assertion.</remarks>
+        [Conditional("DEBUG")]
+        internal static void AreEqual<T>(T expected, T actual)
+        {
+#pragma warning disable RECS0017 // Possible compare of value type with 'null'
+            if (expected == null)
+#pragma warning restore RECS0017 // Possible compare of value type with 'null'
+            {
+                // Two nulls are considered equal, regardless of type semantics.
+#pragma warning disable RECS0017 // Possible compare of value type with 'null'
+                if (actual != null && !actual.Equals(expected))
+#pragma warning restore RECS0017 // Possible compare of value type with 'null'
+                {
+                    Break();
+                }
+            }
+            else if (!expected.Equals(actual))
+            {
+                Break();
+            }
+        }
+
+        /// <summary>
+        /// This line should never be executed.  The assertion always fails.
+        /// </summary>
+        /// <remarks>This breaks into the debugger in the case of a failed assertion.</remarks>
+        [Conditional("DEBUG")]
+        internal static void Fail() => Fail(null);
+
+        /// <summary>
+        /// This line should never be executed.  The assertion always fails.
+        /// </summary>
+        /// <param name="message">The message to display if this function is executed.</param>
+        /// <remarks>This breaks into the debugger in the case of a failed assertion.</remarks>
+        [Conditional("DEBUG")]
+        internal static void Fail(string message) => Break(message);
+
+        /// <summary>
+        /// Verifies that if the specified condition is true, then so is the result.
+        /// The assertion fails if the condition is true but the result is false.
+        /// </summary>
+        /// <param name="condition">if set to <c>true</c> [condition].</param>
+        /// <param name="result">
+        /// A second Boolean statement.  If the first was true then so must this be.
+        /// If the first statement was false then the value of this is ignored.
+        /// </param>
+        /// <remarks>This breaks into the debugger in the case of a failed assertion.</remarks>
+        [Conditional("DEBUG")]
+        internal static void Implies(bool condition, bool result)
+        {
+            if (condition && !result)
+            {
+                Break();
+            }
+        }
+
+        /// <summary>
+        /// Verify the current thread's apartment state is what's expected.  The assertion fails if it isn't
+        /// </summary>
+        /// <param name="expectedState">
+        /// The expected apartment state for the current thread.
+        /// </param>
+        /// <remarks>This breaks into the debugger in the case of a failed assertion.</remarks>
+        [Conditional("DEBUG")]
+        internal static void IsApartmentState(ApartmentState expectedState)
+        {
+            if (Thread.CurrentThread.GetApartmentState() != expectedState)
+            {
+                Break();
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified condition is false.  The assertion fails if it is true.
+        /// </summary>
+        /// <param name="condition">The expression that should be <c>false</c>.</param>
+        /// <remarks>This breaks into the debugger in the case of a failed assertion.</remarks>
+        [Conditional("DEBUG")]
+        internal static void IsFalse(bool condition)
+        {
+            IsFalse(condition, null);
+        }
+
+        /// <summary>
+        /// Verifies that the specified condition is false.  The assertion fails if it is true.
+        /// </summary>
+        /// <param name="condition">The expression that should be <c>false</c>.</param>
+        /// <param name="message">The message to display if the condition is <c>true</c>.</param>
+        /// <remarks>This breaks into the debugger in the case of a failed assertion.</remarks>
+        [Conditional("DEBUG")]
+        internal static void IsFalse(bool condition, string message)
+        {
+            if (condition)
+            {
+                Break(message);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that a string has content.  I.e. it is not null and it is not empty.
+        /// </summary>
+        /// <param name="value">The string to verify.</param>
+        [Conditional("DEBUG")]
+        internal static void IsNeitherNullNorEmpty(string value) => IsFalse(string.IsNullOrEmpty(value));
+
+        /// <summary>
+        /// Verifies that a string has content.  I.e. it is not null and it is not purely whitespace.
+        /// </summary>
+        /// <param name="value">The string to verify.</param>
+        [Conditional("DEBUG")]
+        internal static void IsNeitherNullNorWhitespace(string value) => IsFalse(string.IsNullOrWhiteSpace(value));
+
+        /// <summary>
+        /// Verifies the specified value is not null.  The assertion fails if it is.
+        /// </summary>
+        /// <typeparam name="T">The generic reference type.</typeparam>
+        /// <param name="value">The value to check for nullness.</param>
+        /// <remarks>This breaks into the debugger in the case of a failed assertion.</remarks>
+        [Conditional("DEBUG")]
+        internal static void IsNotNull<T>(T value)
+            where T : class
+        {
+            if (value == null)
+            {
+                Break();
+            }
+        }
+
+        [Conditional("DEBUG")]
+        internal static void IsNotOnMainThread()
+        {
+            if (System.Windows.Application.Current.Dispatcher.CheckAccess())
+            {
+                Break("Is not on WPF main thread");
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified object is null.  The assertion fails if it is not.
+        /// </summary>
+        /// <typeparam name="T">The type of item to verify.</typeparam>
+        /// <param name="item">The item to verify is null.</param>
+        [Conditional("DEBUG")]
+        internal static void IsNull<T>(T item)
+            where T : class
+        {
+            if (item != null)
+            {
+                Break();
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified condition is true.  The assertion fails if it is not.
+        /// </summary>
+        /// <param name="condition">A condition that is expected to be <c>true</c>.</param>
+        /// <remarks>This breaks into the debugger in the case of a failed assertion.</remarks>
+        [Conditional("DEBUG")]
+        internal static void IsTrue(bool condition) => IsTrue(condition, null);
+
+        /// <summary>
+        /// Verifies that the specified condition is true.  The assertion fails if it is not.
+        /// </summary>
+        /// <param name="condition">A condition that is expected to be <c>true</c>.</param>
+        /// <param name="message">The message to write in case the condition is <c>false</c>.</param>
+        /// <remarks>This breaks into the debugger in the case of a failed assertion.</remarks>
+        [Conditional("DEBUG")]
+        internal static void IsTrue(bool condition, string message)
+        {
+            if (!condition)
+            {
+                Break(message);
+            }
+        }
+
+        [Conditional("DEBUG")]
+        private static void Break(string message = null)
+        {
+            // If we're running under a unit test, do some additional checking
+            // Since this method can only be called in DEBUG builds, the additional
+            // cost of enumerating assemblies or walking the stack is forgivable
+            if (IsRunningInUnitTest)
+            {
+                if (Debugger.IsAttached)
+                {
+                    // Since a debugger is attached use the existing behavior
+                    _Break(message);
+                }
+                else
+                {
+                    throw new InvalidOperationException(message ?? "Code encountered a BREAK condition and cannot continue. Review stack for more information.");
+                }
+            }
+            else
+            {
+                _Break(message);
+            }
+        }
+
+        [Conditional("DEBUG")]
+#pragma warning disable SA1300 // Element must begin with upper-case letter
+        private static void _Break(string message)
+#pragma warning restore SA1300 // Element must begin with upper-case letter
+        {
+#pragma warning disable RECS0110 // Condition is set by DEV_DEBUG compile constant
+            if (AggressiveFailFast)
+#pragma warning restore RECS0110 // Condition is set by DEV_DEBUG compile constant
+            {
+#pragma warning disable 162
+                if (!string.IsNullOrEmpty(message))
+                {
+                    Debug.WriteLine(message);
+                }
+
+                Debugger.Break();
+#pragma warning restore 162
+            }
+            else
+#pragma warning disable 162
+            {
+                Debug.Assert(false, message);
+            }
+#pragma warning restore 162
+        }
+
+        private static readonly HashSet<string> UnitTestAttributes = new HashSet<string>
+        {
+            "Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute"
+        };
+
+        private static readonly HashSet<string> UnitTestFrameworks = new HashSet<string>
+        {
+            "Microsoft.VisualStudio.QualityTools.UnitTestFramework",
+            "Microsoft.VisualStudio.TestPlatform.TestFramework"
+        };
+
+        private static bool IsRunningInUnitTest
+        {
+            get
+            {
+                // Check if the current AppDomain has loaded a unit test assembly
+                bool AppDomainHasUnitTestAssembly()
+                {
+                    return AppDomain
+                           .CurrentDomain
+                           .GetAssemblies()
+                           .Any(AssemblyIsUnitTestFramework);
+                }
+
+                bool AssemblyIsUnitTestFramework(Assembly a)
+                {
+                    foreach (var f in UnitTestFrameworks)
+                    {
+                        if (a.FullName.StartsWith(f, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+
+                // Walk the stack and determine if any type has a known attribute for unit tests
+                bool TypeHasUnitTestAttribute()
+                {
+                    return new StackTrace()
+                           .GetFrames()
+                           .Any(f => f
+                                     .GetMethod()
+                                     .DeclaringType
+                                     .GetCustomAttributes(false)
+                                     .Any(x => UnitTestAttributes.Contains(x.GetType().FullName)));
+                }
+
+                return AppDomainHasUnitTestAssembly() || TypeHasUnitTestAttribute();
+            }
+        }
+    }
+}

--- a/Core/Utility/Toolkit/Win32Error.cs
+++ b/Core/Utility/Toolkit/Win32Error.cs
@@ -1,0 +1,188 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace Microsoft.Toolkit.Win32.UI.Controls.Interop.Win32
+{
+    /// <summary>
+    /// Wrapper for common Win32 status codes.
+    /// </summary>
+    [StructLayout(LayoutKind.Explicit)]
+    internal struct Win32Error
+    {
+        [FieldOffset(0)]
+        private readonly int _value;
+
+        // NOTE: These public static field declarations are automatically
+        // picked up by (HRESULT's) ToString through reflection.
+
+        /// <summary>The operation completed successfully.</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May be used in DEBUG")]
+        public static readonly Win32Error ERROR_SUCCESS = new Win32Error(0);
+
+        /// <summary>Incorrect function.</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May be used in DEBUG")]
+        public static readonly Win32Error ERROR_INVALID_FUNCTION = new Win32Error(1);
+
+        /// <summary>The system cannot find the file specified.</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May be used in DEBUG")]
+        public static readonly Win32Error ERROR_FILE_NOT_FOUND = new Win32Error(2);
+
+        /// <summary>The system cannot find the path specified.</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May be used in DEBUG")]
+        public static readonly Win32Error ERROR_PATH_NOT_FOUND = new Win32Error(3);
+
+        /// <summary>The system cannot open the file.</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May be used in DEBUG")]
+        public static readonly Win32Error ERROR_TOO_MANY_OPEN_FILES = new Win32Error(4);
+
+        /// <summary>Access is denied.</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May be used in DEBUG")]
+        public static readonly Win32Error ERROR_ACCESS_DENIED = new Win32Error(5);
+
+        /// <summary>The handle is invalid.</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May be used in DEBUG")]
+        public static readonly Win32Error ERROR_INVALID_HANDLE = new Win32Error(6);
+
+        /// <summary>Not enough storage is available to complete this operation.</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May be used in DEBUG")]
+        public static readonly Win32Error ERROR_OUTOFMEMORY = new Win32Error(14);
+
+        /// <summary>There are no more files.</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May be used in DEBUG")]
+        public static readonly Win32Error ERROR_NO_MORE_FILES = new Win32Error(18);
+
+        /// <summary>The process cannot access the file because it is being used by another process.</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May be used in DEBUG")]
+        public static readonly Win32Error ERROR_SHARING_VIOLATION = new Win32Error(32);
+
+        /// <summary>The parameter is incorrect.</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May be used in DEBUG")]
+        public static readonly Win32Error ERROR_INVALID_PARAMETER = new Win32Error(87);
+
+        /// <summary>The data area passed to a system call is too small.</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May be used in DEBUG")]
+        public static readonly Win32Error ERROR_INSUFFICIENT_BUFFER = new Win32Error(122);
+
+        /// <summary>Cannot nest calls to LoadModule.</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May be used in DEBUG")]
+        public static readonly Win32Error ERROR_NESTING_NOT_ALLOWED = new Win32Error(215);
+
+        /// <summary>Illegal operation attempted on a registry key that has been marked for deletion.</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May be used in DEBUG")]
+        public static readonly Win32Error ERROR_KEY_DELETED = new Win32Error(1018);
+
+        /// <summary>Element not found.</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May be used in DEBUG")]
+        public static readonly Win32Error ERROR_NOT_FOUND = new Win32Error(1168);
+
+        /// <summary>There was no match for the specified key in the index.</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May be used in DEBUG")]
+        public static readonly Win32Error ERROR_NO_MATCH = new Win32Error(1169);
+
+        /// <summary>An invalid device was specified.</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May be used in DEBUG")]
+        public static readonly Win32Error ERROR_BAD_DEVICE = new Win32Error(1200);
+
+        /// <summary>The operation was canceled by the user.</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May be used in DEBUG")]
+        public static readonly Win32Error ERROR_CANCELLED = new Win32Error(1223);
+
+        /// <summary>Not all privileges or groups references are assigned to the caller </summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May be used in DEBUG")]
+        public static readonly Win32Error ERROR_NOT_ALL_ASSIGNED = new Win32Error(1300);
+
+        /// <summary>The window class was already registered.</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May be used in DEBUG")]
+        public static readonly Win32Error ERROR_CLASS_ALREADY_EXISTS = new Win32Error(1410);
+
+        /// <summary>The specified datatype is invalid.</summary>
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "May be used in DEBUG")]
+        public static readonly Win32Error ERROR_INVALID_DATATYPE = new Win32Error(1804);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Win32Error"/> struct.
+        /// </summary>
+        /// <param name="i">The integer value of the error.</param>
+        public Win32Error(int i)
+        {
+            _value = i;
+        }
+
+        /// <summary>Performs HRESULT_FROM_WIN32 conversion.</summary>
+        /// <param name="error">The Win32 error being converted to an HRESULT.</param>
+        /// <returns>The equivalent HRESULT value.</returns>
+        public static explicit operator HRESULT(Win32Error error)
+        {
+            // #define __HRESULT_FROM_WIN32(x)
+            //     ((HRESULT)(x) <= 0 ? ((HRESULT)(x)) : ((HRESULT) (((x) & 0x0000FFFF) | (FACILITY_WIN32 << 16) | 0x80000000)))
+            if (error._value <= 0)
+            {
+                return new HRESULT((uint)error._value);
+            }
+
+            return HRESULT.Make(true, Facility.Win32, error._value & 0x0000FFFF);
+        }
+
+        /// <summary>Performs the equivalent of Win32's GetLastError()</summary>
+        /// <returns>A Win32Error instance with the result of the native GetLastError</returns>
+        [SecurityCritical]
+        public static Win32Error GetLastError()
+        {
+            return new Win32Error(Marshal.GetLastWin32Error());
+        }
+
+        // Method version of the cast operation
+
+        /// <summary>Performs HRESULT_FROM_WIN32 conversion.</summary>
+        /// <returns>The equivalent HRESULT value.</returns>
+        public HRESULT ToHRESULT()
+        {
+            return (HRESULT)this;
+        }
+
+        public override bool Equals(object obj)
+        {
+            try
+            {
+                return ((Win32Error)obj)._value == _value;
+            }
+            catch (InvalidCastException)
+            {
+                return false;
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            return _value.GetHashCode();
+        }
+
+        /// <summary>
+        /// Compare two Win32 error codes for equality.
+        /// </summary>
+        /// <param name="errLeft">The first error code to compare.</param>
+        /// <param name="errRight">The second error code to compare.</param>
+        /// <returns>Whether the two error codes are the same.</returns>
+        public static bool operator ==(Win32Error errLeft, Win32Error errRight)
+        {
+            return errLeft._value == errRight._value;
+        }
+
+        /// <summary>
+        /// Compare two Win32 error codes for inequality.
+        /// </summary>
+        /// <param name="errLeft">The first error code to compare.</param>
+        /// <param name="errRight">The second error code to compare.</param>
+        /// <returns>Whether the two error codes are not the same.</returns>
+        public static bool operator !=(Win32Error errLeft, Win32Error errRight)
+        {
+            return !(errLeft == errRight);
+        }
+    }
+}

--- a/Core/Utility/Toolkit/Windows10Release.cs
+++ b/Core/Utility/Toolkit/Windows10Release.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Toolkit.Win32.UI.Controls.Interop
+{
+    /// <summary>
+    /// Identifies Windows 10 release IDs
+    /// </summary>
+    internal enum Windows10Release
+    {
+        /// <summary>
+        /// Unknown
+        /// </summary>
+        Unknown = 0,
+
+        /// <summary>
+        /// 10.0.10240.0
+        /// </summary>
+        Threshold1 = 1507,
+
+        /// <summary>
+        /// 10.0.10586
+        /// </summary>
+        Threshold2 = 1511,
+
+        /// <summary>
+        /// 10.0.14393.0 (Redstone 1)
+        /// </summary>
+        Anniversary = 1607,
+
+        /// <summary>
+        /// 10.0.15063.0 (Redstone 2)
+        /// </summary>
+        Creators = 1703,
+
+        /// <summary>
+        /// 10.0.16299.0 (Redstone 3)
+        /// </summary>
+        FallCreators = 1709,
+
+        /// <summary>
+        /// 10.0.17134.0 (Redstone 4)
+        /// </summary>
+        April2018 = 1803,
+    }
+}

--- a/Core/Utility/Toolkit/WindowsVersions.cs
+++ b/Core/Utility/Toolkit/WindowsVersions.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Toolkit.Win32.UI.Controls.Interop
+{
+    internal enum WindowsVersions
+    {
+        Win7,
+        Server2008R2,   // 6.1
+        Win8,
+        Server2012,     // 6.2
+        Win81,
+        Server2012R2,   // 6.3
+        Win10,
+        Server2016,     // 10.0
+    }
+}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,6 +125,7 @@ jobs:
 
   - task: whitesource.ws-bolt.bolt.wss.WhiteSource Bolt@18
     displayName: 'WhiteSource Bolt'
+    enabled: false
 
   - task: DotNetCoreCLI@2  
     inputs:


### PR DESCRIPTION
Fixes #503 

Some code paths cause issues on Windows 7:

```
System.ComponentModel.Composition.CompositionException: The composition produced a single composition error. The root cause is provided below. Review the CompositionException.Errors property for more detailed information.

1) Operation is not supported on this platform.

Resulting in: Could not find Windows Runtime type 'Windows.Storage.ApplicationData'.

Resulting in: The type initializer for 'PackageExplorer.SettingsManager' threw an exception.

Resulting in: An exception occurred while trying to create an instance of type 'PackageExplorer.SettingsManager'.

Resulting in: Cannot activate part 'PackageExplorer.SettingsManager'.

Element: PackageExplorer.SettingsManager -->  PackageExplorer.SettingsManager -->  AssemblyCatalog (Assembly="NuGetPackageExplorer, Version=4.5.0.0, Culture=neutral, PublicKeyToken=null")

Resulting in: Cannot get export 'PackageExplorer.SettingsManager (ContractName="NuGetPackageExplorer.Types.ISettingsManager")' from part 'PackageExplorer.SettingsManager'.

Element: PackageExplorer.SettingsManager (ContractName="NuGetPackageExplorer.Types.ISettingsManager") -->  PackageExplorer.SettingsManager -->  AssemblyCatalog (Assembly="NuGetPackageExplorer, Version=4.5.0.0, Culture=neutral, PublicKeyToken=null")

   at System.ComponentModel.Composition.Hosting.CompositionServices.GetExportedValueFromComposedPart(ImportEngine engine, ComposablePart part, ExportDefinition definition)
   at System.ComponentModel.Composition.Hosting.CatalogExportProvider.GetExportedValue(CatalogPart part, ExportDefinition export, bool isSharedPart)
   at System.ComponentModel.Composition.Hosting.CatalogExportProvider+CatalogExport.GetExportedValueCore()
   at System.ComponentModel.Composition.Primitives.Export.get_Value()
   at System.ComponentModel.Composition.ExportServices.GetCastedExportedValue<T>(Export export)
   at System.ComponentModel.Composition.Hosting.ExportProvider.GetExportedValueCore<T>(string contractName, ImportCardinality cardinality)
   at System.ComponentModel.Composition.Hosting.ExportProvider.GetExportedValue<T>(string contractName)
   at System.ComponentModel.Composition.Hosting.ExportProvider.GetExportedValue<T>()
   at PackageExplorer.App+<Application_Startup>d__4.MoveNext() in D:\a\1\s\PackageExplorer\App.xaml.cs:line 62
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore+<>c.<ThrowAsync>b__6_0(object state)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, object args, int numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(object source, Delegate callback, object args, int numArgs, Delegate catchHandler)
   at System.Windows.Threading.DispatcherOperation.InvokeImpl()
   at System.Windows.Threading.DispatcherOperation.InvokeInSecurityContext(object state)
   at MS.Internal.CulturePreservingExecutionContext.CallbackWrapper(object obj)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, object state, bool preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, object state, bool preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, object state)
   at MS.Internal.CulturePreservingExecutionContext.Run(CulturePreservingExecutionContext executionContext, ContextCallback callback, object state)
   at System.Windows.Threading.DispatcherOperation.Invoke()
   at System.Windows.Threading.Dispatcher.ProcessQueue()
   at System.Windows.Threading.Dispatcher.WndProcHook(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
   at MS.Win32.HwndWrapper.WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
   at MS.Win32.HwndSubclass.DispatcherCallbackOperation(object o)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, object args, int numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(object source, Delegate callback, object args, int numArgs, Delegate catchHandler)
   at System.Windows.Threading.Dispatcher.LegacyInvokeImpl(DispatcherPriority priority, TimeSpan timeout, Delegate method, object args, int numArgs)
   at MS.Win32.HwndSubclass.SubclassWndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam)
   at MS.Win32.UnsafeNativeMethods.DispatchMessage(ref MSG msg)
   at System.Windows.Threading.Dispatcher.PushFrameImpl(DispatcherFrame frame)
   at System.Windows.Threading.Dispatcher.PushFrame(DispatcherFrame frame)
   at System.Windows.Application.RunDispatcher(object ignore)
   at System.Windows.Application.RunInternal(Window window)
   at System.Windows.Application.Run(Window window)
   at System.Windows.Application.Run()
   at PackageExplorer.App.Main()
```