### PR TITLE
use separate variables for package source and package path

### DIFF
--- a/PackageExplorer/MainWindow.xaml.cs
+++ b/PackageExplorer/MainWindow.xaml.cs
@@ -223,7 +223,7 @@ namespace PackageExplorer
 
                 try
                 {
-                    var packageViewModel = await PackageViewModelFactory.CreateViewModel(package, packagePath);
+                    var packageViewModel = await PackageViewModelFactory.CreateViewModel(package, packagePath, packageSource);
                     packageViewModel.PropertyChanged += OnPackageViewModelPropertyChanged;
 
                     DataContext = packageViewModel;

--- a/PackageExplorer/MainWindow.xaml.cs
+++ b/PackageExplorer/MainWindow.xaml.cs
@@ -173,7 +173,7 @@ namespace PackageExplorer
 
                 if (package != null)
                 {
-                    LoadPackage(package, packagePath, PackageType.LocalPackage);
+                    LoadPackage(package, packagePath, packagePath, PackageType.LocalPackage);
                     _tempFile = tempFile;
                     return true;
                 }
@@ -199,7 +199,7 @@ namespace PackageExplorer
             return false;
         }
 
-        private async void LoadPackage(IPackage package, string packagePath, PackageType packageType)
+        private async void LoadPackage(IPackage package, string packagePath, string packageSource, PackageType packageType)
         {
             DisposeViewModel();
 
@@ -227,9 +227,9 @@ namespace PackageExplorer
                     packageViewModel.PropertyChanged += OnPackageViewModelPropertyChanged;
 
                     DataContext = packageViewModel;
-                    if (!string.IsNullOrEmpty(packagePath))
+                    if (!string.IsNullOrEmpty(packageSource))
                     {
-                        _mruManager.NotifyFileAdded(package, packagePath, packageType);
+                        _mruManager.NotifyFileAdded(package, packageSource, packageType);
                     }
                 }
                 catch (Exception e)
@@ -293,7 +293,7 @@ namespace PackageExplorer
                 return;
             }
 
-            LoadPackage(new EmptyPackage(), string.Empty, PackageType.LocalPackage);
+            LoadPackage(new EmptyPackage(), string.Empty, string.Empty, PackageType.LocalPackage);
         }
 
         private void OpenMenuItem_Click(object sender, ExecutedRoutedEventArgs e)
@@ -357,6 +357,7 @@ namespace PackageExplorer
             DispatcherOperation processPackageAction(ISignaturePackage package)
             {
                 LoadPackage(package,
+                            package.Source,
                             repository.PackageSource.Source,
                             PackageType.RemotePackage);
 
@@ -561,7 +562,7 @@ namespace PackageExplorer
                 var downloadedPackage = await PackageDownloader.Download(repository, packageIdentity);
                 if (downloadedPackage != null)
                 {
-                    LoadPackage(downloadedPackage, packageUrl, PackageType.RemotePackage);
+                    LoadPackage(downloadedPackage, downloadedPackage.Source, packageUrl, PackageType.RemotePackage);
                 }
             }
             else

--- a/PackageExplorer/NuGetPackageExplorer.csproj
+++ b/PackageExplorer/NuGetPackageExplorer.csproj
@@ -43,9 +43,4 @@
     </Resource>
   </ItemGroup>
 
-  <ItemGroup>
-    <Page Update="Xaml\Icons.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-  </ItemGroup>
 </Project>

--- a/PackageExplorer/NuGetPackageExplorer.csproj
+++ b/PackageExplorer/NuGetPackageExplorer.csproj
@@ -43,4 +43,9 @@
     </Resource>
   </ItemGroup>
 
+  <ItemGroup>
+    <Page Update="Xaml\Icons.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
 </Project>

--- a/PackageViewModel/Commands/SavePackageCommand.cs
+++ b/PackageViewModel/Commands/SavePackageCommand.cs
@@ -143,7 +143,7 @@ namespace PackageExplorerViewModel
                 }
             }
 
-            var succeeded = SavePackage(ViewModel.PackageSource);
+            var succeeded = SavePackage(ViewModel.PackagePath);
             if (succeeded)
             {
                 RaiseCanExecuteChangedEvent();
@@ -184,6 +184,7 @@ namespace PackageExplorerViewModel
                 var succeeded = SavePackage(selectedPackagePath);
                 if (succeeded)
                 {
+                    ViewModel.PackagePath = selectedPackagePath;
                     ViewModel.PackageSource = selectedPackagePath;
                 }
             }
@@ -258,6 +259,7 @@ namespace PackageExplorerViewModel
                     {
                         File.Copy(signedPackagePath, selectedPackagePath, overwrite: true);
                         ViewModel.OnSaved(selectedPackagePath);
+                        ViewModel.PackagePath = selectedPackagePath;
                         ViewModel.PackageSource = selectedPackagePath;
                         ViewModel.PackageMetadata.ClearSignatures();
                         using (var package = new ZipPackage(selectedPackagePath))

--- a/PackageViewModel/PackageViewModel.cs
+++ b/PackageViewModel/PackageViewModel.cs
@@ -46,6 +46,7 @@ namespace PackageExplorerViewModel
         private bool _isInEditMode;
         private RelayCommand<object>? _openContentFileCommand;
         private ICommand? _openWithContentFileCommand;
+        private string _packagePath;
         private string _packageSource;
         private RelayCommand? _publishCommand;
         private RelayCommand<object>? _renameContentCommand;
@@ -63,6 +64,7 @@ namespace PackageExplorerViewModel
 
         internal PackageViewModel(
             IPackage package,
+            string path,
             string source,
             IMruManager mruManager,
             IUIServices uiServices,
@@ -83,7 +85,8 @@ namespace PackageExplorerViewModel
 
             _packageMetadata = new EditablePackageMetadata(_package, UIServices);
 
-            _packageSource = source;
+            PackagePath = path;
+            PackageSource = source;
 
             _isSigned = _packageMetadata.IsSigned;
 
@@ -228,14 +231,14 @@ namespace PackageExplorerViewModel
             }
         }
 
-        public string PackageSource
+        public string PackagePath
         {
-            get { return _packageSource; }
+            get { return _packagePath; }
             set
             {
-                if (_packageSource != value)
+                if (_packagePath != value)
                 {
-                    _packageSource = value;
+                    _packagePath = value;
                     OnPropertyChanged("PackageSource");
 
                     // This may be a URI or a file
@@ -259,11 +262,24 @@ namespace PackageExplorerViewModel
                             _watcher.Deleted += OnFileChange;
                             _watcher.Renamed += OnFileChange;
 
-                            _watcher.Path = Path.GetDirectoryName(PackageSource);
-                            _watcher.Filter = Path.GetFileName(PackageSource);
+                            _watcher.Path = Path.GetDirectoryName(PackagePath);
+                            _watcher.Filter = Path.GetFileName(PackagePath);
                             _watcher.EnableRaisingEvents = true;
                         }
                     }
+                }
+            }
+        }
+
+        public string PackageSource
+        {
+            get { return _packageSource; }
+            set
+            {
+                if (_packageSource != value)
+                {
+                    _packageSource = value;
+                    OnPropertyChanged();
                 }
             }
         }
@@ -343,7 +359,7 @@ namespace PackageExplorerViewModel
             {
                 UIServices.Show(e.Message, MessageLevel.Error);
             }
-            
+
         }
 
         private void AddExistingFileToFolder(PackageFolder folder)
@@ -653,7 +669,7 @@ namespace PackageExplorerViewModel
             {
                 UIServices.Show(e.Message, MessageLevel.Error);
             }
-            
+
         }
 
         #endregion
@@ -709,7 +725,7 @@ namespace PackageExplorerViewModel
             {
                 UIServices.Show(e.Message, MessageLevel.Error);
             }
-            
+
         }
 
         private bool SaveContentCanExecute(PackageFile file)
@@ -869,7 +885,7 @@ namespace PackageExplorerViewModel
             var package = PackageHelper.BuildPackage(PackageMetadata, GetFiles());
             try
             {
-                packageCommand.Value.Execute(package, PackageSource);
+                packageCommand.Value.Execute(package, PackagePath);
             }
             catch (Exception ex)
             {
@@ -1227,7 +1243,7 @@ namespace PackageExplorerViewModel
                 // handle signed packages since they cannot be resaved without losing the signature
                 if (IsSigned)
                 {
-                    File.Copy(PackageSource, tempFile, overwrite: true);
+                    File.Copy(PackagePath, tempFile, overwrite: true);
                 }
                 else
                 {
@@ -1293,7 +1309,7 @@ namespace PackageExplorerViewModel
         public IEnumerable<PackageIssue> Validate()
         {
             var package = PackageHelper.BuildPackage(PackageMetadata, GetFiles());
-            var packageFileName = Path.IsPathRooted(PackageSource) ? Path.GetFileName(PackageSource) : string.Empty;
+            var packageFileName = Path.IsPathRooted(PackagePath) ? Path.GetFileName(PackagePath) : string.Empty;
             return package.Validate(_packageRules.Select(r => r.Value), packageFileName);
         }
 

--- a/PackageViewModel/PackageViewModel.cs
+++ b/PackageViewModel/PackageViewModel.cs
@@ -62,7 +62,9 @@ namespace PackageExplorerViewModel
 
         #endregion
 
+#pragma warning disable CS8618 // Non-nullable field is uninitialized.
         internal PackageViewModel(
+#pragma warning restore CS8618 // Non-nullable field is uninitialized.
             IPackage package,
             string path,
             string source,

--- a/PackageViewModel/PackageViewModelFactory.cs
+++ b/PackageViewModel/PackageViewModelFactory.cs
@@ -60,7 +60,7 @@ namespace PackageExplorerViewModel
 
         #region IPackageViewModelFactory Members
 
-        public async Task<PackageViewModel> CreateViewModel(IPackage package, string packageSource)
+        public async Task<PackageViewModel> CreateViewModel(IPackage package, string packagePath, string packageSource)
         {
             // If it's a zip package, we need to load the verification data so it's ready for later
             if (package is ISignaturePackage zip)
@@ -70,6 +70,7 @@ namespace PackageExplorerViewModel
 
             return new PackageViewModel(
                 package,
+                packagePath,
                 packageSource,
                 MruManager,
                 UIServices,

--- a/PackageViewModel/Types/IPackageViewModelFactory.cs
+++ b/PackageViewModel/Types/IPackageViewModelFactory.cs
@@ -6,7 +6,7 @@ namespace NuGetPackageExplorer.Types
 {
     public interface IPackageViewModelFactory
     {
-        Task<PackageViewModel> CreateViewModel(IPackage package, string packageSource);
+        Task<PackageViewModel> CreateViewModel(IPackage package, string packagePath, string packageSource);
         PackageChooserViewModel CreatePackageChooserViewModel(string? fixedPackageSource);
         PluginManagerViewModel CreatePluginManagerViewModel();
     }


### PR DESCRIPTION
this is a quick fix for #650 
Now the `PackageSource` in the `PackageViewModel` is always the package path. Which means that if a package is opened from a feed, the feed name is no longer shown in the package view but instead the temp path to the package.
If we want to preserve the previous behavior we also have to use separate variables for package source and package path in the `PackageViewModel` which would require more changes.