### PR TITLE
Update for a known breaking change

### DIFF
--- a/PackageExplorer/Converters/StringShortenerConverter.cs
+++ b/PackageExplorer/Converters/StringShortenerConverter.cs
@@ -26,7 +26,7 @@ namespace PackageExplorer
             var prefixLength = (maxLength - 3) / 2;
             var suffixLength = maxLength - 3 - prefixLength;
 
-            return stringValue.Substring(0, prefixLength) + "..." + stringValue.Substring(^suffixLength);
+            return stringValue.Substring(0, prefixLength) + "..." + stringValue.Substring((^suffixLength).GetOffset(0));
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)


### PR DESCRIPTION
Update for a known breaking change made by BCL tracked by https://github.com/dotnet/corefx/issues/35972. String Substring(Index startIndex) is removed in the new version of .NET Core 3.0 Preview4, you can use the SDK from https://dotnet.microsoft.com/download/thank-you/dotnet-sdk-3.0.100-preview4-windows-x64-installer to build the project.