### PR TITLE
Show complete version in package list & autosize package version columns

### DIFF
--- a/PackageExplorer/PackageChooser/PackageDetailActionsControl.xaml
+++ b/PackageExplorer/PackageChooser/PackageDetailActionsControl.xaml
@@ -47,7 +47,7 @@
             HorizontalAlignment="Stretch"
             MaxHeight="150"
             Visibility="{Binding ShowingAllVersionsList, Converter={StaticResource boolToVis}}"
-            IsTextSearchEnabled="False">
+            IsTextSearchEnabled="False" VirtualizingStackPanel.IsVirtualizing="False">
 
             <ListView.ItemContainerStyle>
                 <Style TargetType="ListViewItem">
@@ -68,7 +68,7 @@
             <ListView.View>
                 <GridView AllowsColumnReorder="False" x:Name="PackageGridView">
 
-                    <GridViewColumn Width="80" Header="{x:Static self:Resources.PackageChooser_ColumnHeaderVersion}">
+                    <GridViewColumn Header="{x:Static self:Resources.PackageChooser_ColumnHeaderVersion}">
                         <GridViewColumn.HeaderContainerStyle>
                             <Style TargetType="{x:Type GridViewColumnHeader}">
                                 <Setter Property="HorizontalContentAlignment" Value="Right"/>

--- a/PackageExplorer/PackageChooser/PackageDetailActionsControl.xaml.cs
+++ b/PackageExplorer/PackageChooser/PackageDetailActionsControl.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System.ComponentModel;
+using System.Windows;
 using System.Windows.Controls;
 using NuGetPe;
 using PackageExplorerViewModel;
@@ -30,6 +31,38 @@ namespace PackageExplorer
         {
             var viewModel = (PackageInfoViewModel)DataContext;
             viewModel.OpenCommand.Execute(null);
+        }
+
+        protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e)
+        {
+            base.OnPropertyChanged(e);
+
+            if (e.Property == DataContextProperty)
+            {
+                if (e.NewValue is PackageInfoViewModel newViewModel)
+                {
+                    newViewModel.PropertyChanged += PackageInfoViewModel_PropertyChanged;
+                }
+                if (e.OldValue is PackageInfoViewModel oldViewModel)
+                {
+                    oldViewModel.PropertyChanged -= PackageInfoViewModel_PropertyChanged;
+                }
+            }
+        }
+
+        private void PackageInfoViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(PackageInfoViewModel.HasFinishedLoading))
+            {
+                foreach (var column in PackageGridView.Columns)
+                {
+                    if (double.IsNaN(column.Width))
+                    {
+                        column.Width = 0;
+                        column.Width = double.NaN;
+                    }
+                }
+            }
         }
     }
 }

--- a/PackageExplorer/PackageChooser/PackageListItem.xaml
+++ b/PackageExplorer/PackageChooser/PackageListItem.xaml
@@ -9,8 +9,8 @@
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="45"/>
-            <ColumnDefinition Width="0.8*"/>
-            <ColumnDefinition Width="0.2*"/>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="Auto"/>
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>


### PR DESCRIPTION
First commit shows the complete version in the package list.
Second commit autosizes the package version columns. (Had to disable virtualization for that...)

fixes #694