### PR TITLE
use correct .nuspec filename during export

### DIFF
--- a/PackageViewModel/PackageViewModel.cs
+++ b/PackageViewModel/PackageViewModel.cs
@@ -1364,7 +1364,7 @@ this);
             RootFolder.Export(rootPath);
 
             // export .nuspec file
-            ExportManifest(Path.Combine(rootPath, PackageMetadata + ".nuspec"));
+            ExportManifest(Path.Combine(rootPath, PackageMetadata.FileName + NuGetPe.Constants.ManifestExtension));
         }
 
         internal void ExportManifest(string fullpath, bool askForConfirmation = true, bool includeFilesSection = true)


### PR DESCRIPTION
it is now the same code as here:
https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/blob/290c8f97cd3fad41f1c37866bf36a3e9ad32756c/PackageViewModel/Commands/SavePackageCommand.cs#L199
https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/blob/290c8f97cd3fad41f1c37866bf36a3e9ad32756c/PackageViewModel/PackageViewModel.cs#L1082

fixes #720