### PR TITLE
also fire property change for IsSignedOrInEditMetadataMode

### DIFF
--- a/PackageViewModel/PackageViewModel.cs
+++ b/PackageViewModel/PackageViewModel.cs
@@ -111,7 +111,8 @@ namespace PackageExplorerViewModel
                 if (_isInEditMode != value)
                 {
                     _isInEditMode = value;
-                    OnPropertyChanged("IsInEditMetadataMode");
+                    OnPropertyChanged(nameof(IsInEditMetadataMode));
+                    OnPropertyChanged(nameof(IsSignedOrInEditMetadataMode));
                 }
             }
         }
@@ -135,6 +136,7 @@ namespace PackageExplorerViewModel
                 {
                     _isSigned = value;
                     OnPropertyChanged(nameof(IsSigned));
+                    OnPropertyChanged(nameof(IsSignedOrInEditMetadataMode));
                     _saveCommand?.RaiseCanExecuteChangedEvent();
                 }
             }


### PR DESCRIPTION
- show / hide the edit metadata button after adding / removing the package signature
- show / hide the edit metadata button after editing the package metadata

![image](https://user-images.githubusercontent.com/4009570/59865046-6886a280-9388-11e9-9744-d937353c44de.png)
