### PR TITLE
Make text selectable in AssemblyMetadata panel

### DIFF
--- a/PackageExplorer/App.xaml
+++ b/PackageExplorer/App.xaml
@@ -90,6 +90,21 @@
                 </Style.Triggers>
             </Style>
 
+            <!-- Clone of SelectableTextBlockLikeStyle, but without triggers -->
+            <Style x:Key="SelectableTextBlockLikeStyleWithoutTriggers" TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
+                <Setter Property="IsReadOnly" Value="True"/>
+                <Setter Property="IsTabStop" Value="False"/>
+                <Setter Property="BorderThickness" Value="0"/>
+                <Setter Property="Background" Value="Transparent"/>
+                <Setter Property="Padding" Value="-2,0,0,0"/>
+                <!-- The Padding -2,0,0,0 is required because the TextBox
+        seems to have an inherent "Padding" of about 2 pixels.
+        Without the Padding property,
+        the text seems to be 2 pixels to the left
+        compared to a TextBlock
+    -->
+            </Style>
+
             <Style TargetType="{x:Type Image}" x:Key="ImageStyleBase">
                 <Setter Property="Width" Value="16" />
                 <Setter Property="Height" Value="16" />

--- a/PackageExplorer/MefServices/AssemblyFileViewer.cs
+++ b/PackageExplorer/MefServices/AssemblyFileViewer.cs
@@ -110,21 +110,25 @@ namespace PackageExplorer
             grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) });
             grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) });
 
+            var style =  Application.Current.FindResource("SelectableTextBlockLikeStyleWithoutTriggers") as Style;
+
             foreach (var data in orderedAssemblyDataEntries)
             {
-                var label = new TextBlock
+                var label = new TextBox
                 {
                     Text = data.Key + ':',
                     FontWeight = FontWeights.SemiBold,
-                    Margin = new Thickness(3, 3, 10, 0)
+                    Margin = new Thickness(3, 3, 10, 0),
+                    Style = style
                 };
                 Grid.SetRow(label, grid.RowDefinitions.Count);
                 Grid.SetColumn(label, 0);
 
-                var value = new TextBlock
+                var value = new TextBox
                 {
                     Text = data.Value,
-                    Margin = new Thickness(0, 3, 3, 0)
+                    Margin = new Thickness(0, 3, 3, 0),
+                    Style = style
                 };
                 Grid.SetRow(value, grid.RowDefinitions.Count);
                 Grid.SetColumn(value, 1);


### PR DESCRIPTION
Makes the text selectable in the "AssemblyMetadata" panel:

![image](https://user-images.githubusercontent.com/5808377/62168779-9f0bf180-b326-11e9-8d0e-da1c6ffcfafd.png)

This is maybe a poor-mans solution, but haven't found another solution.

needed because: I need sometimes the PublicKeyToken and I don't like typing hex ;)