### PR TITLE
Don't show strange publish and wrong download count values for unlisted packages

### DIFF
--- a/Core/Packages/PackageInfo.cs
+++ b/Core/Packages/PackageInfo.cs
@@ -20,7 +20,7 @@ namespace NuGetPe
         public string? Description { get; set; }
         public string? Summary { get; set; }
         public string? Authors { get; set; }
-        public int DownloadCount { get; set; }
+        public int? DownloadCount { get; set; }
         public DateTimeOffset? Published { get; set; }
 
         public string? IconUrl { get; set; }

--- a/PackageViewModel/PackageChooser/PackageInfoViewModel.cs
+++ b/PackageViewModel/PackageChooser/PackageInfoViewModel.cs
@@ -298,11 +298,29 @@ namespace PackageExplorerViewModel
         {
             var versionInfo = versionInfos?.FirstOrDefault(v => v.Version == packageSearchMetadata.Identity.Version);
 
+            DateTimeOffset? published = null;
+            int? downloadCount = null;
+
+            if (packageSearchMetadata.Published.HasValue && packageSearchMetadata.Published.Value.Year > 1900)
+            {
+                // Note nuget.org reports 1900 for unlisted packages. Pretty sure it's was published later ;)
+                published = packageSearchMetadata.Published;
+            }
+
+            downloadCount = (int)(versionInfo?.DownloadCount ?? packageSearchMetadata.DownloadCount.GetValueOrDefault());
+
+            if (!packageSearchMetadata.IsListed && versionInfo == null && downloadCount == 0)
+            {
+                // Note nuget.org reports no correct download counts in for unlisted. 
+                downloadCount = null;
+
+            }
+
             return new PackageInfo(packageSearchMetadata.Identity)
             {
                 Authors = packageSearchMetadata.Authors,
-                Published = packageSearchMetadata.Published,
-                DownloadCount = (int)(versionInfo?.DownloadCount ?? packageSearchMetadata.DownloadCount.GetValueOrDefault()),
+                Published = published,
+                DownloadCount = downloadCount,
                 IsRemotePackage = (feedType == FeedType.HttpV3 || feedType == FeedType.HttpV2),
                 IsPrefixReserved = packageSearchMetadata.PrefixReserved,
                 Description = packageSearchMetadata.Description,


### PR DESCRIPTION
For unlisted packages the download count is wrong and the publish date is strange (i'm pretty sure I didn't released that day ;))

Download counts on nuget.org:

![image](https://user-images.githubusercontent.com/5808377/62169645-12aefe00-b329-11e9-8768-5f6e508410ae.png)


Solution for now: don't show those if unlisted.

![image](https://user-images.githubusercontent.com/5808377/62169617-fa3ee380-b328-11e9-85c8-ef46bb77e797.png)

I'm not sure if this is only an issue of nuget.org. Not sure if we need to test it and how. (another option is to test the date, e.g. before 1901, but not sure how to check the downloads then)