### PR TITLE
Don't show 0 downloads

### DIFF
--- a/PackageExplorer/PackageChooser/PackageListItem.xaml
+++ b/PackageExplorer/PackageChooser/PackageListItem.xaml
@@ -29,8 +29,10 @@
                                        Visibility="{Binding LatestPackageInfo.IsPrefixReserved, Converter={StaticResource boolToVis}}"/>
             <TextBlock HorizontalAlignment="Stretch" Margin="4,0,0,0">
                                 by
-                                <Run Text="{Binding LatestPackageInfo.Authors, Mode=OneWay}"/>,
-                                <Run Text="{Binding LatestPackageInfo.DownloadCount, Mode=OneWay, Converter={StaticResource NumberToStringConverter}}" FontWeight="Bold"/> downloads
+                                <Run Text="{Binding LatestPackageInfo.Authors, Mode=OneWay}"/>
+                                <TextBlock Visibility="{Binding LatestPackageInfo.DownloadCount, Mode=OneWay, Converter={StaticResource NullToVisibilityConverter}}">,</TextBlock>
+                                <Run Text="{Binding LatestPackageInfo.DownloadCount, Mode=OneWay, Converter={StaticResource NumberToStringConverter}}" FontWeight="Bold"/>
+                                <TextBlock Visibility="{Binding LatestPackageInfo.DownloadCount,  Mode=OneWay,Converter={StaticResource NullToVisibilityConverter}}">downloads</TextBlock>
             </TextBlock>
 
         </StackPanel>

--- a/PackageViewModel/PackageChooser/PackageInfoViewModel.cs
+++ b/PackageViewModel/PackageChooser/PackageInfoViewModel.cs
@@ -309,7 +309,7 @@ namespace PackageExplorerViewModel
 
             downloadCount = (int)(versionInfo?.DownloadCount ?? packageSearchMetadata.DownloadCount.GetValueOrDefault());
 
-            if (!packageSearchMetadata.IsListed && versionInfo == null && downloadCount == 0)
+            if (downloadCount == 0)
             {
                 // Note nuget.org reports no correct download counts in for unlisted. 
                 downloadCount = null;


### PR DESCRIPTION
Proposal/discussion

before:

![image](https://user-images.githubusercontent.com/5808377/62413612-213f3300-b611-11e9-99b6-cf0da864ab7b.png)


after:


![image](https://user-images.githubusercontent.com/5808377/62413813-b80cef00-b613-11e9-9902-4342d9b6b4a0.png)

Less clutter and looks like the download count is more then once wrong if 0

follow up of https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/pull/740

(this is the 
with this feed: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json feed)