### PR TITLE
Improve performance of PackageChooserDialog with static feeds

### DIFF
--- a/PackageViewModel/PackageChooser/PackageChooserViewModel.cs
+++ b/PackageViewModel/PackageChooser/PackageChooserViewModel.cs
@@ -319,7 +319,7 @@ namespace PackageExplorerViewModel
                 }
 
                 ClearMessage();
-                ShowPackages(packageInfos, _currentQuery.BeginPackage, _currentQuery.EndPackage);
+                ShowPackages(packageInfos, packageInfos.Count, _currentQuery.BeginPackage, _currentQuery.EndPackage);
             }
             catch (OperationCanceledException)
             {
@@ -361,12 +361,22 @@ namespace PackageExplorerViewModel
             return new List<IPackageSearchMetadata>();
         }
 
-        private void ShowPackages(IEnumerable<IPackageSearchMetadata> packages, int beginPackage, int endPackage)
+        private void ShowPackages(IEnumerable<IPackageSearchMetadata> packages, int packagesCount, int beginPackage, int endPackage)
         {
             Packages.Clear();
+
             if (ActiveRepository != null)
             {
                 var ar = ActiveRepository;
+                var skip = beginPackage - 1;
+                var count = endPackage - skip;
+
+                if (packagesCount > count + skip)
+                {
+                    // more packages then needed.
+                    packages = packages.Skip(skip).Take(count);
+                }
+
                 Packages.AddRange(packages.Select(p => new PackageInfoViewModel(p, ShowPrereleasePackages, ar, _feedType, this)));
             }
             UpdatePageNumber(beginPackage, endPackage);


### PR DESCRIPTION
Tested with https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
~ 1900 feeds

![image](https://user-images.githubusercontent.com/5808377/62414065-2acb9980-b617-11e9-8d0b-664674b573af.png)


before ~37 sec
after ~16 sec

We really should know if feeds are static (also for search), related https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/issues/607