### PR TITLE
Update Dependencies

### DIFF
--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="AppInsights.WindowsDesktop" Version="2.10.46" />
     <PackageReference Include="Microsoft.DiaSymReader.Converter" Version="1.1.0-beta1-64128-01" />
     <PackageReference Include="OSVersionHelper" Version="1.0.11" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.7.0-preview5.19224.8" />    
+    <PackageReference Include="System.Reflection.Metadata" Version="1.7.0-preview7.19362.9" />    
     <Reference Include="Windows" />
   </ItemGroup>
   

--- a/PackageExplorer/NuGetPackageExplorer.csproj
+++ b/PackageExplorer/NuGetPackageExplorer.csproj
@@ -15,13 +15,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AvalonEdit" Version="6.0.0-netcore3p4alpha1" />
+    <PackageReference Include="AvalonEdit" Version="6.0.0-preview1" />
     <PackageReference Include="GrayscaleEffect" Version="1.0.1" />
     <PackageReference Include="Humanizer" Version="2.6.2" />
     <PackageReference Include="Ookii.Dialogs.Wpf" Version="1.1.0" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
-    <PackageReference Include="System.Runtime.Caching" Version="4.5.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.6.0-preview7.19362.9" />
+    <PackageReference Include="System.Runtime.Caching" Version="4.6.0-preview7.19362.9" />
 
     <Reference Include="Windows" />
 

--- a/PackageViewModel/PackageViewModel.csproj
+++ b/PackageViewModel/PackageViewModel.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Web.Xdt" Version="2.1.2" /> 
     <PackageReference Include="NuGet.Commands" Version="5.3.0-xprivate.60011" />
     <PackageReference Include="NuGet.Resolver" Version="5.3.0-xprivate.60011" />
-    <PackageReference Include="System.Windows.Extensions" Version="4.6.0-preview5.19224.8" />
+    <PackageReference Include="System.Windows.Extensions" Version="4.6.0-preview7.19362.9" />
     <ProjectReference Include="..\Core\Core.csproj" />
   </ItemGroup>
 

--- a/PackageViewModel/PackageViewModel.csproj
+++ b/PackageViewModel/PackageViewModel.csproj
@@ -10,12 +10,12 @@
   
   <ItemGroup>
     <PackageReference Include="AuthenticodeExaminer" Version="0.3.0" />
-    <PackageReference Include="NuGet.Credentials" Version="5.3.0-xprivate.60008" />
-    <PackageReference Include="NuGet.PackageManagement" Version="5.3.0-xprivate.60008" />
+    <PackageReference Include="NuGet.Credentials" Version="5.3.0-xprivate.60011" />
+    <PackageReference Include="NuGet.PackageManagement" Version="5.3.0-xprivate.60011" />
     <!-- Needs 2.1.2 explicitly until https://github.com/NuGet/Home/issues/5957 is fixed -->
     <PackageReference Include="Microsoft.Web.Xdt" Version="2.1.2" /> 
-    <PackageReference Include="NuGet.Commands" Version="5.3.0-xprivate.60008" />
-    <PackageReference Include="NuGet.Resolver" Version="5.3.0-xprivate.60008" />
+    <PackageReference Include="NuGet.Commands" Version="5.3.0-xprivate.60011" />
+    <PackageReference Include="NuGet.Resolver" Version="5.3.0-xprivate.60011" />
     <PackageReference Include="System.Windows.Extensions" Version="4.6.0-preview5.19224.8" />
     <ProjectReference Include="..\Core\Core.csproj" />
   </ItemGroup>

--- a/Types/Types.csproj
+++ b/Types/Types.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <!--<PackageReference Include="Microsoft.Web.Xdt" Version="3.0.0" />-->
     <PackageReference Include="NuGet.Packaging" Version="5.3.0-xprivate.60011" />
-    <PackageReference Include="System.ComponentModel.Composition" Version="4.5.0" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="4.6.0-preview7.19362.9" />
   </ItemGroup>
   
 </Project>

--- a/Types/Types.csproj
+++ b/Types/Types.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <!--<PackageReference Include="Microsoft.Web.Xdt" Version="3.0.0" />-->
-    <PackageReference Include="NuGet.Packaging" Version="5.3.0-xprivate.60008" />
+    <PackageReference Include="NuGet.Packaging" Version="5.3.0-xprivate.60011" />
     <PackageReference Include="System.ComponentModel.Composition" Version="4.5.0" />
   </ItemGroup>
   


### PR DESCRIPTION
Updates to latest private NuGet.

May fix #625 by specifying `CredentialCache.DefaultCredentials` on the handler.