### PR TITLE
Put a lock around read/write of settings

### DIFF
--- a/PackageExplorer/MefServices/SettingsManager.cs
+++ b/PackageExplorer/MefServices/SettingsManager.cs
@@ -23,6 +23,8 @@ namespace PackageExplorer
 
         public event PropertyChangedEventHandler PropertyChanged;
 
+        private readonly object lockObject = new object();
+
         private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
@@ -30,52 +32,55 @@ namespace PackageExplorer
 
         private T GetValue<T>([CallerMemberName] string? name = null)
         {
-            object value;
-            try
+            lock(lockObject)
             {
-                if (WindowsVersionHelper.HasPackageIdentity)
+                object value;
+                try
                 {
-                    value = GetValueFromLocalSettings<T>(name!)!;
+                    if (WindowsVersionHelper.HasPackageIdentity)
+                    {
+                        value = GetValueFromLocalSettings<T>(name!)!;
+                    }
+                    else
+                    {
+                        value = Settings.Default[name];
+                        if (typeof(T) == typeof(List<string>) && value is StringCollection sc)
+                        {
+                            value = sc.Cast<string>().ToArray();
+                        }
+                    }
+
+                    if (value is T t)
+                    {
+                        return t;
+                    }
                 }
-                else
+                catch (ConfigurationErrorsException)
                 {
+                    // Corrupt settings file
+                    Settings.Default.Reset();
+
+                    // Try getting it again
                     value = Settings.Default[name];
                     if (typeof(T) == typeof(List<string>) && value is StringCollection sc)
                     {
                         value = sc.Cast<string>().ToArray();
                     }
-                }
 
-                if (value is T t)
+                    if (value is T t)
+                    {
+                        return t;
+                    }
+                }
+                catch (UnauthorizedAccessException)
+                { }
+                catch (IOException)
                 {
-                    return t;
-                }
-            }
-            catch (ConfigurationErrorsException)
-            {
-                // Corrupt settings file
-                Settings.Default.Reset();
-
-                // Try getting it again
-                value = Settings.Default[name];
-                if (typeof(T) == typeof(List<string>) && value is StringCollection sc)
-                {
-                    value = sc.Cast<string>().ToArray();
+                    // not much we can do if we can't read/write the settings file
                 }
 
-                if (value is T t)
-                {
-                    return t;
-                }
-            }
-            catch (UnauthorizedAccessException)
-            { }
-            catch (IOException)
-            {
-                // not much we can do if we can't read/write the settings file
-            }
-
-            return default!;
+                return default!;
+            }            
         }
 
         // Don't load these types inline
@@ -97,29 +102,32 @@ namespace PackageExplorer
         {
             name ??= propertyName;
 
-            try
+            lock(lockObject)
             {
-                if (WindowsVersionHelper.HasPackageIdentity)
+                try
                 {
-                    SetValueInLocalSettings(value, name!);
-                }
-                else
-                {
-                    if (value is List<string> list)
+                    if (WindowsVersionHelper.HasPackageIdentity)
                     {
-                        var sc = new StringCollection();
-                        sc.AddRange(list.ToArray());
-                        value = sc;
+                        SetValueInLocalSettings(value, name!);
                     }
-                    Settings.Default[name] = value;
+                    else
+                    {
+                        if (value is List<string> list)
+                        {
+                            var sc = new StringCollection();
+                            sc.AddRange(list.ToArray());
+                            value = sc;
+                        }
+                        Settings.Default[name] = value;
+                    }
                 }
-            }
-            catch (UnauthorizedAccessException)
-            { }
-            catch (IOException)
-            {
-                // not much we can do if we can't read/write the settings file
-            }
+                catch (UnauthorizedAccessException)
+                { }
+                catch (IOException)
+                {
+                    // not much we can do if we can't read/write the settings file
+                }
+            }            
 
             OnPropertyChanged(propertyName);
         }

--- a/PackageViewModel/MruPackageSourceManager.cs
+++ b/PackageViewModel/MruPackageSourceManager.cs
@@ -20,16 +20,12 @@ namespace PackageExplorerViewModel
         public string ActivePackageSource { get; set; }
 
         public ObservableCollection<string> PackageSources { get; } = new ObservableCollection<string>();
-
-        #region IDisposable Members
-
+        
         public void Dispose()
         {
             _sourceSettings.SetSources(PackageSources);
             _sourceSettings.ActiveSource = ActivePackageSource;
         }
-
-        #endregion
 
         private void LoadDataFromSettings()
         {
@@ -71,7 +67,7 @@ namespace PackageExplorerViewModel
         {
             if (newSource == null)
             {
-                throw new ArgumentNullException("newSource");
+                throw new ArgumentNullException(nameof(newSource));
             }
 
             var defaultFeed = _sourceSettings.DefaultSource;

--- a/PackageViewModel/PackageChooser/PackageChooserViewModel.cs
+++ b/PackageViewModel/PackageChooser/PackageChooserViewModel.cs
@@ -340,6 +340,8 @@ namespace PackageExplorerViewModel
                     return;
                 }
 
+                DiagnosticsClient.TrackException(exception);
+
                 var errorMessage = exception.Message;
 
                 ShowMessage(errorMessage, true);

--- a/PackageViewModel/PackageChooser/PackageSourceSettings.cs
+++ b/PackageViewModel/PackageChooser/PackageSourceSettings.cs
@@ -23,8 +23,6 @@ namespace PackageExplorerViewModel
             }
         }
 
-        #region ISourceSettings Members
-
         public IList<string> GetSources()
         {
             var sources = _settingsManager.GetPackageSources();
@@ -58,7 +56,5 @@ namespace PackageExplorerViewModel
             get { return _settingsManager.ActivePackageSource; }
             set { _settingsManager.ActivePackageSource = value; }
         }
-
-        #endregion
     }
 }


### PR DESCRIPTION
 and log exceptions that happen loading a feed

Relates to #730 but isn't a specific fix.