### PR TITLE
Added local packages search for static feeds

### DIFF
--- a/PackageViewModel/PackageChooser/PackageChooserViewModel.cs
+++ b/PackageViewModel/PackageChooser/PackageChooserViewModel.cs
@@ -11,6 +11,7 @@ using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGetPackageExplorer.Types;
 using NuGetPe;
+using PackageExplorerViewModel.PackageSearch;
 
 namespace PackageExplorerViewModel
 {
@@ -238,7 +239,8 @@ namespace PackageExplorerViewModel
         public event EventHandler OpenPackageRequested = delegate { };
         public event EventHandler PackageDownloadRequested = delegate { };
 
-
+        private readonly PackageListCache<IPackageSearchMetadata> _packageListCache = new PackageListCache<IPackageSearchMetadata>();
+        
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling"),
          System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         private async Task LoadPackages()
@@ -256,7 +258,7 @@ namespace PackageExplorerViewModel
                 return;
             }
 
-            _currentQuery = new ShowLatestVersionQueryContext<IPackageSearchMetadata>(repository, _currentSearch, ShowPrereleasePackages, PackageListPageSize);
+            _currentQuery = new ShowLatestVersionQueryContext<IPackageSearchMetadata>(repository, _currentSearch, ShowPrereleasePackages, PackageListPageSize, _packageListCache);
             _feedType = await repository.GetFeedType(usedTokenSource.Token);
 
             await LoadPage(CurrentCancellationTokenSource.Token);
@@ -370,15 +372,6 @@ namespace PackageExplorerViewModel
             if (ActiveRepository != null)
             {
                 var ar = ActiveRepository;
-                var skip = beginPackage - 1;
-                var count = endPackage - skip;
-
-                if (packagesCount > count + skip)
-                {
-                    // more packages then needed.
-                    packages = packages.Skip(skip).Take(count);
-                }
-
                 Packages.AddRange(packages.Select(p => new PackageInfoViewModel(p, ShowPrereleasePackages, ar, _feedType, this)));
             }
             UpdatePageNumber(beginPackage, endPackage);

--- a/PackageViewModel/PackageChooser/ShowLatestVersionQueryContext.cs
+++ b/PackageViewModel/PackageChooser/ShowLatestVersionQueryContext.cs
@@ -1,31 +1,35 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
+using PackageExplorerViewModel.PackageSearch;
 
 namespace PackageExplorerViewModel
 {
     internal class ShowLatestVersionQueryContext<T> : IQueryContext<T> where T : IPackageSearchMetadata
     {
         private readonly SourceRepository _sourceRepository;
-        private readonly string? _searchText;
-        private readonly SearchFilter _searchFilter;
+        private readonly SearchContext _searchContext;
         private readonly int _pageSize;
         private PackageSearchResource? _packageSearchResouce;
         private RawSearchResourceV3? _rawPackageSearchResouce;
         private int? _lastPageIndex;
         private int _lastPageCount;
+        private readonly PackageListCache<T> _packageListCache;
+        private readonly LocalPackageSearcher<T> _localPackageSearcher;
 
-        public ShowLatestVersionQueryContext(SourceRepository sourceRepository, string? search, bool showPreReleasePackages, int pageSize)
+        public ShowLatestVersionQueryContext(SourceRepository sourceRepository, string? search, bool showPreReleasePackages, int pageSize, PackageListCache<T> packageListCache)
         {
             _sourceRepository = sourceRepository;
-            _searchText = search;
-            _searchFilter = new SearchFilter(showPreReleasePackages);
+            _searchContext = new SearchContext(search, new SearchFilter(showPreReleasePackages));
             _pageSize = pageSize;
+            _packageListCache = packageListCache ?? throw new ArgumentNullException(nameof(packageListCache));
+            _localPackageSearcher = new LocalPackageSearcher<T>(_searchContext);
         }
 
         #region IQueryContext<T> Members
@@ -40,16 +44,70 @@ namespace PackageExplorerViewModel
 
         public async Task<IList<T>> GetItemsForCurrentPage(CancellationToken token)
         {
-            IEnumerable<IPackageSearchMetadata>? result = null;
-
-            if (_searchText?.StartsWith("id:", StringComparison.OrdinalIgnoreCase) == true)
+            var packageSource = _sourceRepository.PackageSource.Source;
+            List<T> list;
+            if (_packageListCache.TryGetPackages(packageSource, out var packages))
             {
-                var id = _searchText?.Substring(3).Trim();
-                if (!string.IsNullOrEmpty(id))
-                {
-                    var findPackageByIdResource = await _sourceRepository.GetResourceAsync<PackageMetadataResource>();
+                list = LocalSearch(packages);
+            }
+            else
+            {
+                list = await SearchOnServer(token);
 
-                    var metadata = await findPackageByIdResource.GetMetadataAsync(id, _searchFilter.IncludePrerelease, true, NullSourceCacheContext.Instance, NullLogger.Instance, token);
+                if (list.Count > _pageSize)
+                {
+                    // More packages than requested, assume static feed
+                    _packageListCache.SetPackages(packageSource, list);
+                    list = LocalSearch(list);
+                }
+            }
+
+            if (list.Count < _pageSize)
+            {
+                _lastPageIndex = CurrentPage;
+                _lastPageCount = list.Count;
+            }
+
+            return list;
+        }
+
+        private List<T> LocalSearch(IEnumerable<T> packages)
+        {
+            var items = _localPackageSearcher.SearchPackages(packages);
+
+            var list = ApplyPaging(items, _pageSize);
+            return list;
+        }
+
+        private List<T> ApplyPaging(IEnumerable<T> packages, int pageSize)
+        {
+            var packagesList = packages.ToList();
+            if (packagesList.Count > pageSize)
+            {
+                var skip = BeginPackage - 1;
+                var count = EndPackage - skip;
+
+                if (packagesList.Count > count + skip)
+                {
+                    // more packages then needed.
+                    packagesList = packagesList.Skip(skip).Take(count).ToList();
+                }
+            }
+
+            return packagesList;
+        }
+
+        private async Task<List<T>> SearchOnServer(CancellationToken token)
+        {
+            var searchText = _searchContext.SearchText;
+            IEnumerable<IPackageSearchMetadata>? result = null;
+            if (_searchContext.IsIdSearch)
+            {
+                if (!string.IsNullOrEmpty(searchText))
+                {
+                    var findPackageByIdResource = await _sourceRepository.GetResourceAsync<PackageMetadataResource>(token);
+
+                    var metadata = await findPackageByIdResource.GetMetadataAsync(searchText, _searchContext.Filter.IncludePrerelease, true, NullSourceCacheContext.Instance, NullLogger.Instance, token);
 
                     result = metadata.OrderByDescending(m => m.Identity.Version).Take(1);
                 }
@@ -64,9 +122,10 @@ namespace PackageExplorerViewModel
                 {
                     _rawPackageSearchResouce = await _sourceRepository.GetResourceAsync<RawSearchResourceV3>(token);
                 }
+                
                 if (_rawPackageSearchResouce != null)
                 {
-                    var json = await _rawPackageSearchResouce.Search(_searchText, _searchFilter, CurrentPage * _pageSize, _pageSize, NullLogger.Instance, token);
+                    var json = await _rawPackageSearchResouce.Search(searchText, _searchContext.Filter, CurrentPage * _pageSize, _pageSize, NullLogger.Instance, token);
 
                     result = json.Select(s => s.FromJToken<PackageSearchMetadata>());
                 }
@@ -78,20 +137,13 @@ namespace PackageExplorerViewModel
                         _packageSearchResouce = await _sourceRepository.GetResourceAsync<PackageSearchResource>(token);
                     }
 
-                    result = await _packageSearchResouce.SearchAsync(_searchText, _searchFilter, CurrentPage * _pageSize, _pageSize, NullLogger.Instance, token);
+                    result = await _packageSearchResouce.SearchAsync(searchText, _searchContext.Filter, CurrentPage * _pageSize, _pageSize, NullLogger.Instance, token);
                 }
             }
 
             token.ThrowIfCancellationRequested();
 
             var list = result.Cast<T>().ToList();
-
-            if (list.Count < _pageSize)
-            {
-                _lastPageIndex = CurrentPage;
-                _lastPageCount = list.Count;
-            }
-
             return list;
         }
 

--- a/PackageViewModel/PackageSearch/LocalPackageSearcher.cs
+++ b/PackageViewModel/PackageSearch/LocalPackageSearcher.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+
+namespace PackageExplorerViewModel.PackageSearch
+{
+    class LocalPackageSearcher<T> where T : IPackageSearchMetadata
+    {
+        private readonly SearchContext _searchContext;
+
+        public LocalPackageSearcher(SearchContext searchContext)
+        {
+            _searchContext = searchContext;
+        }
+
+        public IEnumerable<T> SearchPackages(IEnumerable<T> packages)
+        {
+            var searchText = _searchContext.SearchText;
+            var searchFilter = _searchContext.Filter;
+
+            if (!searchFilter.IncludePrerelease)
+            {
+                packages = packages.Where(p => p is PackageSearchMetadata meta && !meta.Version.IsPrerelease);
+            }
+
+            if (_searchContext.IsIdSearch)
+            {
+                packages = packages.Where(p => string.Equals(p.Identity.Id, searchText, StringComparison.OrdinalIgnoreCase));
+            }
+            else if (!String.IsNullOrEmpty(searchText))
+            {
+                // Support multiple terms
+                var searchValues = SplitValues(searchText, " ");
+
+                packages = packages
+                    .Select(p => new { score = searchValues.Sum(s => CalcScore(p, s)), package = p })
+                    .Where(it => it.score > 0) // first filtering before sorting for performance reasons
+                    .OrderByDescending(it => it.score)
+                    .Select(it => it.package);
+            }
+
+            return packages;
+        }
+
+        private static int CalcScore(T package, string searchText)
+        {
+            var score = ScoreForEquals(package.Identity.Id, searchText);
+
+            score += ScoreForContains(package.Identity.Id, searchText);
+            score += ScoreForContains(package.Title, searchText);
+            score += ScoreForContains(package.Summary, searchText);
+            score += ScoreForContains(package.Description, searchText);
+
+            var tags = SplitValues(package.Tags, " ");
+            score += ScoreForContains(tags, searchText);
+
+            var authors = SplitValues(package.Authors, ",");
+            score += ScoreForContains(authors, searchText);
+
+            if (package.DownloadCount != null)
+            {
+                // From: NuGet.Services.Metadata
+                // This score ranges from 0 to less than 100, assuming that the most downloaded
+                // package has less than 500 million downloads. This scoring function increases
+                // quickly at first and then becomes approximately linear near the upper bound.
+                var downloadScore = (int)Math.Sqrt(package.DownloadCount.Value) / 220;
+                score += downloadScore;
+            }
+
+            return score;
+        }
+
+        private static int ScoreForContains(IEnumerable<string> values, string searchText)
+        {
+            return values.Sum(t => ScoreForContains(t, searchText));
+        }
+
+        private static IEnumerable<string> SplitValues(string value, string separator)
+        {
+            if (value == null)
+            {
+                return new List<string>();
+            }
+            var values = value.Split(separator, StringSplitOptions.RemoveEmptyEntries).Select(t => t.Trim());
+            return values;
+        }
+
+        private static int ScoreForContains(string text, string searchText)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return 0;
+            }
+            return text.Contains(searchText, StringComparison.OrdinalIgnoreCase) ? 1 : 0;
+        }
+
+        private static int ScoreForEquals(string text, string searchText)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return 0;
+            }
+            return text.Equals(searchText, StringComparison.OrdinalIgnoreCase) ? 5 : 0;
+        }
+    }
+}

--- a/PackageViewModel/PackageSearch/PackageListCache.cs
+++ b/PackageViewModel/PackageSearch/PackageListCache.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using NuGet.Protocol.Core.Types;
+
+namespace PackageExplorerViewModel.PackageSearch
+{
+    internal class PackageListCache<T>  where T : IPackageSearchMetadata
+    {
+        private readonly Dictionary<string, List<T>> _packagesDict = new Dictionary<string, List<T>>(StringComparer.OrdinalIgnoreCase);
+
+        public void SetPackages(string packageSource, List<T> packages)
+        {
+            _packagesDict[packageSource] = packages;
+        }
+
+        public bool TryGetPackages(string packageSource, out List<T> packages)
+        {
+            return _packagesDict.TryGetValue(packageSource, out packages);
+        }
+    }
+}

--- a/PackageViewModel/PackageSearch/SearchContext.cs
+++ b/PackageViewModel/PackageSearch/SearchContext.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using NuGet.Protocol.Core.Types;
+
+namespace PackageExplorerViewModel.PackageSearch
+{
+    public class SearchContext
+    {
+        public string? SearchText { get; }
+
+        public SearchFilter Filter { get; }
+
+        public bool IsIdSearch { get; }
+
+        public SearchContext(string? searchText, SearchFilter filter)
+        {
+            if (searchText?.StartsWith("id:", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                IsIdSearch = true;
+                SearchText = searchText.Substring(3).Trim();
+            }
+            else
+            {
+                SearchText = searchText;
+            }
+
+            Filter = filter ?? throw new ArgumentNullException(nameof(filter));
+        }
+    }
+}


### PR DESCRIPTION
Including prelease filter, id filter, paging and ranked sorting. Fixes #607

Tested with https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json

Initial load is still a bit slow (~16 sec), but after that search and paging is fast!

(yes, this won't work with static feeds if they have <= 15 packages)