### PR TITLE
Don't use SocketHttpHandler because of authentification issues with …

### DIFF
--- a/PackageExplorer/App.xaml.cs
+++ b/PackageExplorer/App.xaml.cs
@@ -25,6 +25,10 @@ namespace PackageExplorer
         public App()
 #pragma warning restore CS8618 // Non-nullable field is uninitialized.
         {
+            // Don't use the SocketHttphandler because it has some authentification issues accessing feeds like GitHub NuGet
+            // see https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/pull/841 for more details
+            AppContext.SetSwitch("System.Net.Http.UseSocketsHttpHandler", false);
+
             DiagnosticsClient.Initialize();
         }
 


### PR DESCRIPTION
…GitHub NuGet feeds

The `SocketHttpHandler` has some issues with resending the same request multiple times. Which is what `NuGet.Client` does for authentification. Because of that the authentification for GitHub NuGet package feeds does not work. Because we are using the default credentials for the first authorization request and after that the `SocketHttpClient` does not send the updated credentials from the user. Because the GitHub NuGet API does not send a `Www-Authenticate` header if an `Authorization` header was provided.

https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/blob/e95bd234fdaa74e2367a29dc141ec8275e2d08d0/PackageExplorer/MefServices/CredentialManager.cs#L45

To try it out use your GitHub NuGet feed (`https://nuget.pkg.github.com/GITHUBUSER/index.json`).

See https://github.com/dotnet/corefx/issues/25163#issuecomment-538009706 for more details