### PR TITLE
Disable sign button before each certificate validation

### DIFF
--- a/PackageViewModel/SignPackageViewModel.cs
+++ b/PackageViewModel/SignPackageViewModel.cs
@@ -426,6 +426,7 @@ namespace PackageExplorerViewModel
 
         private void Clear()
         {
+            CanSign = false;
             ShowProgress = false;
             HasError = false;
             Status = null;


### PR DESCRIPTION
Pretty minor, but when the user selects a valid certificate and changes it afterwards to an invalid one or just messes the password up after it was correctly entered then the sign button was still enabled.