### PR TITLE
Feature/native targets filename rule

### DIFF
--- a/PackageViewModel/PackageAnalyzer/MisnamedNativeBuildFileRule.cs
+++ b/PackageViewModel/PackageAnalyzer/MisnamedNativeBuildFileRule.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Linq;
+using NuGetPackageExplorer.Types;
+using NuGetPe;
+
+namespace PackageExplorerViewModel.Rules
+{
+    [Export(typeof(IPackageRule))]
+    internal class MisnamedNativeBuildFileRule : IPackageRule
+    {
+        #region IPackageRule Members
+
+        public IEnumerable<PackageIssue> Validate(IPackage package, string packagePath)
+        {
+            var files =
+                package.GetFiles().Where(x =>
+                    x.Path.EndsWith(".props", StringComparison.OrdinalIgnoreCase) ||
+                    x.Path.EndsWith(".targets", StringComparison.OrdinalIgnoreCase));
+
+            foreach (var file in files)
+            {
+                var path = file.Path;
+                var segments = path.Split('\\');
+
+                var frameworkFolder = segments[^2];
+                var filename = segments.Last();
+                var filenameWithoutExtension = Path.GetFileNameWithoutExtension(filename);
+
+                if (string.Equals(frameworkFolder, "native", StringComparison.OrdinalIgnoreCase) &&
+                    filenameWithoutExtension != package.Id)
+                {
+                    yield return CreatePackageIssueForMisnamedNativeBuildFile(filename, package.Id);
+                }
+            }
+        }
+
+        #endregion
+
+
+        private static PackageIssue CreatePackageIssueForMisnamedNativeBuildFile(string filename, string packageName)
+        {
+            return new PackageIssue(
+                PackageIssueLevel.Warning,
+                "Native build file misnamed",
+                $"The build file '{filename}' does not match the nuget package name. For native packages, this will cause incorrect behavior when being referenced.",
+                $"Rename the build file '{filename}' to match the Nuget package name '{packageName}'."
+            );
+        }
+    }
+}

--- a/PackageViewModel/PackageAnalyzer/MisplacedAssemblyRule.cs
+++ b/PackageViewModel/PackageAnalyzer/MisplacedAssemblyRule.cs
@@ -65,7 +65,7 @@ namespace PackageExplorerViewModel.Rules
                 "Assembly outside known folders",
                 "The assembly '" + target +
                 $"' is not inside the '{folder}' folder and hence it won't be used when the package is installed into a project",
-                "Move it into a known folder folder."
+                "Move it into a known folder."
                 );
         }
     }


### PR DESCRIPTION
This PR adds a new analysis rule that requires native Nuget packages to have their .targets file match their package name.

This resolves #845.