### PR TITLE
Multiselect in package contents list

### DIFF
--- a/PackageExplorer/Controls/MultiSelectTreeView.cs
+++ b/PackageExplorer/Controls/MultiSelectTreeView.cs
@@ -57,15 +57,20 @@ namespace PackageExplorer.Controls
             if (treeViewItem != null && treeView != null)
             {
                 var selectedItems = GetSelectedItems(treeView);
+
                 if (selectedItems != null)
                 {
                     if (GetIsItemSelected(treeViewItem))
                     {
-                        selectedItems.Add(treeViewItem.Header);
+                        if (selectedItems.Contains(treeViewItem.DataContext))
+                        {
+                            return;
+                        }
+                        selectedItems.Add(treeViewItem.DataContext);
                     }
                     else
                     {
-                        selectedItems.Remove(treeViewItem.Header);
+                        selectedItems.Remove(treeViewItem.DataContext);
                     }
                 }
             }

--- a/PackageExplorer/Controls/MultiSelectTreeView.cs
+++ b/PackageExplorer/Controls/MultiSelectTreeView.cs
@@ -132,7 +132,7 @@ namespace PackageExplorer.Controls
             var currentTime = DateTime.Now;
 
             // This is to prevent case, when holding CONTROL, GotFocus triggers twice (not all the time), so selected item do not get unselected right after
-            if ((currentTime - _lastTime).Milliseconds < 100)
+            if ((currentTime - _lastTime).Milliseconds < 5)
             {
                 return;
             }

--- a/PackageExplorer/Controls/MultiSelectTreeView.cs
+++ b/PackageExplorer/Controls/MultiSelectTreeView.cs
@@ -13,9 +13,19 @@ namespace PackageExplorer.Controls
     {
         public MultiSelectTreeView()
         {
-            GotFocus += OnTreeViewItemGotFocus;
-            PreviewMouseLeftButtonDown += OnTreeViewItemPreviewMouseDown;
-            PreviewMouseLeftButtonUp += OnTreeViewItemPreviewMouseUp;
+            Loaded += (s, a) =>
+            {
+                GotFocus += OnTreeViewItemGotFocus;
+                PreviewMouseLeftButtonDown += OnTreeViewItemPreviewMouseDown;
+                PreviewMouseLeftButtonUp += OnTreeViewItemPreviewMouseUp;
+            };
+
+            Unloaded += (s, a) =>
+            {
+                GotFocus -= OnTreeViewItemGotFocus;
+                PreviewMouseLeftButtonDown -= OnTreeViewItemPreviewMouseDown;
+                PreviewMouseLeftButtonUp -= OnTreeViewItemPreviewMouseUp;
+            };
         }
 
         private static TreeViewItem _selectTreeViewItemOnMouseUp;

--- a/PackageExplorer/Controls/MultiSelectTreeView.cs
+++ b/PackageExplorer/Controls/MultiSelectTreeView.cs
@@ -28,14 +28,19 @@ namespace PackageExplorer.Controls
             };
         }
 
-        private static TreeViewItem _selectTreeViewItemOnMouseUp;
-
+        private static TreeViewItem? _selectTreeViewItemOnMouseUp;
+        private static DateTime _lastTime = DateTime.Now;
 
         public static readonly DependencyProperty IsItemSelectedProperty = DependencyProperty.RegisterAttached("IsItemSelected", typeof(Boolean), typeof(MultiSelectTreeView), new PropertyMetadata(false, OnIsItemSelectedPropertyChanged));
 
-        public static bool GetIsItemSelected(TreeViewItem element)
+        public static bool GetIsItemSelected(TreeViewItem? element)
         {
-            return (bool)element.GetValue(IsItemSelectedProperty);
+            if (element != null)
+            {
+                return (bool)element.GetValue(IsItemSelectedProperty);
+            }
+
+            return false;
         }
 
         public static void SetIsItemSelected(TreeViewItem element, Boolean value)
@@ -70,12 +75,26 @@ namespace PackageExplorer.Controls
 
         public static IList GetSelectedItems(TreeView element)
         {
-            return (IList)element.GetValue(SelectedItemsProperty);
+            if (element != null)
+            {
+                return (IList)element.GetValue(SelectedItemsProperty);
+            }
+            else
+            {
+                throw new ArgumentException("TreeView element is null. Cannot set value for null element.");
+            }
         }
 
         public static void SetSelectedItems(TreeView element, IList value)
         {
-            element.SetValue(SelectedItemsProperty, value);
+            if (element != null)
+            {
+                element.SetValue(SelectedItemsProperty, value);
+            }
+            else
+            {
+                throw new ArgumentException("TreeView element is null. Cannot set value for null element.");
+            }
         }
 
         private static readonly DependencyProperty StartItemProperty = DependencyProperty.RegisterAttached("StartItem", typeof(TreeViewItem), typeof(MultiSelectTreeView));
@@ -86,7 +105,7 @@ namespace PackageExplorer.Controls
             return (TreeViewItem)element.GetValue(StartItemProperty);
         }
 
-        private static void SetStartItem(TreeView element, TreeViewItem value)
+        private static void SetStartItem(TreeView element, TreeViewItem? value)
         {
             element.SetValue(StartItemProperty, value);
         }
@@ -105,10 +124,19 @@ namespace PackageExplorer.Controls
                 return;
             }
 
+            var currentTime = DateTime.Now;
+
+            // This is to prevent case, when holding CONTROL, GotFocus triggers twice (not all the time), so selected item do not get unselected right after
+            if ((currentTime - _lastTime).Milliseconds < 100)
+            {
+                return;
+            }
+
             SelectItems(treeViewItem, sender as TreeView);
+            _lastTime = DateTime.Now;
         }
 
-        private static void SelectItems(TreeViewItem treeViewItem, TreeView treeView)
+        private static void SelectItems(TreeViewItem? treeViewItem, TreeView? treeView)
         {
             if (treeViewItem != null && treeView != null)
             {
@@ -149,7 +177,7 @@ namespace PackageExplorer.Controls
             }
         }
 
-        private static TreeViewItem FindTreeViewItem(DependencyObject dependencyObject)
+        private static TreeViewItem? FindTreeViewItem(DependencyObject? dependencyObject)
         {
             if (!(dependencyObject is Visual || dependencyObject is Visual3D))
                 return null;
@@ -171,7 +199,7 @@ namespace PackageExplorer.Controls
             SetStartItem(treeView, treeViewItem);
         }
 
-        private static void DeSelectAllItems(TreeView treeView, TreeViewItem treeViewItem)
+        private static void DeSelectAllItems(TreeView? treeView, TreeViewItem? treeViewItem)
         {
             if (treeView != null)
             {
@@ -185,7 +213,7 @@ namespace PackageExplorer.Controls
                     }
                 }
             }
-            else
+            else if (treeViewItem != null)
             {
                 for (int i = 0; i < treeViewItem.Items.Count; i++)
                 {
@@ -199,7 +227,7 @@ namespace PackageExplorer.Controls
             }
         }
 
-        private static TreeView FindTreeView(DependencyObject dependencyObject)
+        private static TreeView? FindTreeView(DependencyObject? dependencyObject)
         {
             if (dependencyObject == null)
             {
@@ -270,7 +298,7 @@ namespace PackageExplorer.Controls
             }
         }
 
-        private static void GetAllItems(TreeView treeView, TreeViewItem treeViewItem, ICollection<TreeViewItem> allItems)
+        private static void GetAllItems(TreeView? treeView, TreeViewItem? treeViewItem, ICollection<TreeViewItem> allItems)
         {
             if (treeView != null)
             {
@@ -284,7 +312,7 @@ namespace PackageExplorer.Controls
                     }
                 }
             }
-            else
+            else if (treeViewItem != null)
             {
                 for (int i = 0; i < treeViewItem.Items.Count; i++)
                 {

--- a/PackageExplorer/Controls/MultiSelectTreeView.cs
+++ b/PackageExplorer/Controls/MultiSelectTreeView.cs
@@ -1,0 +1,291 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Media3D;
+
+namespace PackageExplorer.Controls
+{
+    public class MultiSelectTreeView : TreeView
+    {
+        public MultiSelectTreeView()
+        {
+            GotFocus += OnTreeViewItemGotFocus;
+            PreviewMouseLeftButtonDown += OnTreeViewItemPreviewMouseDown;
+            PreviewMouseLeftButtonUp += OnTreeViewItemPreviewMouseUp;
+        }
+
+        private static TreeViewItem _selectTreeViewItemOnMouseUp;
+
+
+        public static readonly DependencyProperty IsItemSelectedProperty = DependencyProperty.RegisterAttached("IsItemSelected", typeof(Boolean), typeof(MultiSelectTreeView), new PropertyMetadata(false, OnIsItemSelectedPropertyChanged));
+
+        public static bool GetIsItemSelected(TreeViewItem element)
+        {
+            return (bool)element.GetValue(IsItemSelectedProperty);
+        }
+
+        public static void SetIsItemSelected(TreeViewItem element, Boolean value)
+        {
+            if (element == null) return;
+
+            element.SetValue(IsItemSelectedProperty, value);
+        }
+
+        private static void OnIsItemSelectedPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var treeViewItem = d as TreeViewItem;
+            var treeView = FindTreeView(treeViewItem);
+            if (treeViewItem != null && treeView != null)
+            {
+                var selectedItems = GetSelectedItems(treeView);
+                if (selectedItems != null)
+                {
+                    if (GetIsItemSelected(treeViewItem))
+                    {
+                        selectedItems.Add(treeViewItem.Header);
+                    }
+                    else
+                    {
+                        selectedItems.Remove(treeViewItem.Header);
+                    }
+                }
+            }
+        }
+
+        public static readonly DependencyProperty SelectedItemsProperty = DependencyProperty.RegisterAttached("SelectedItems", typeof(IList), typeof(MultiSelectTreeView));
+
+        public static IList GetSelectedItems(TreeView element)
+        {
+            return (IList)element.GetValue(SelectedItemsProperty);
+        }
+
+        public static void SetSelectedItems(TreeView element, IList value)
+        {
+            element.SetValue(SelectedItemsProperty, value);
+        }
+
+        private static readonly DependencyProperty StartItemProperty = DependencyProperty.RegisterAttached("StartItem", typeof(TreeViewItem), typeof(MultiSelectTreeView));
+
+
+        private static TreeViewItem GetStartItem(TreeView element)
+        {
+            return (TreeViewItem)element.GetValue(StartItemProperty);
+        }
+
+        private static void SetStartItem(TreeView element, TreeViewItem value)
+        {
+            element.SetValue(StartItemProperty, value);
+        }
+
+
+        private static void OnTreeViewItemGotFocus(object sender, RoutedEventArgs e)
+        {
+            _selectTreeViewItemOnMouseUp = null;
+
+            if (e.OriginalSource is TreeView) return;
+
+            var treeViewItem = FindTreeViewItem(e.OriginalSource as DependencyObject);
+            if (Mouse.LeftButton == MouseButtonState.Pressed && GetIsItemSelected(treeViewItem) && Keyboard.Modifiers != ModifierKeys.Control)
+            {
+                _selectTreeViewItemOnMouseUp = treeViewItem;
+                return;
+            }
+
+            SelectItems(treeViewItem, sender as TreeView);
+        }
+
+        private static void SelectItems(TreeViewItem treeViewItem, TreeView treeView)
+        {
+            if (treeViewItem != null && treeView != null)
+            {
+                if ((Keyboard.Modifiers & (ModifierKeys.Control | ModifierKeys.Shift)) == (ModifierKeys.Control | ModifierKeys.Shift))
+                {
+                    SelectMultipleItemsContinuously(treeView, treeViewItem, true);
+                }
+                else if (Keyboard.Modifiers == ModifierKeys.Control)
+                {
+                    SelectMultipleItemsRandomly(treeView, treeViewItem);
+                }
+                else if (Keyboard.Modifiers == ModifierKeys.Shift)
+                {
+                    SelectMultipleItemsContinuously(treeView, treeViewItem);
+                }
+                else
+                {
+                    SelectSingleItem(treeView, treeViewItem);
+                }
+            }
+        }
+
+        private static void OnTreeViewItemPreviewMouseDown(object sender, MouseEventArgs e)
+        {
+            var treeViewItem = FindTreeViewItem(e.OriginalSource as DependencyObject);
+
+            if (treeViewItem != null && treeViewItem.IsFocused)
+                OnTreeViewItemGotFocus(sender, e);
+        }
+
+        private static void OnTreeViewItemPreviewMouseUp(object sender, MouseButtonEventArgs e)
+        {
+            var treeViewItem = FindTreeViewItem(e.OriginalSource as DependencyObject);
+
+            if (treeViewItem == _selectTreeViewItemOnMouseUp)
+            {
+                SelectItems(treeViewItem, sender as TreeView);
+            }
+        }
+
+        private static TreeViewItem FindTreeViewItem(DependencyObject dependencyObject)
+        {
+            if (!(dependencyObject is Visual || dependencyObject is Visual3D))
+                return null;
+
+            var treeViewItem = dependencyObject as TreeViewItem;
+            if (treeViewItem != null)
+            {
+                return treeViewItem;
+            }
+
+            return FindTreeViewItem(VisualTreeHelper.GetParent(dependencyObject));
+        }
+
+        private static void SelectSingleItem(TreeView treeView, TreeViewItem treeViewItem)
+        {
+            // first deselect all items
+            DeSelectAllItems(treeView, null);
+            SetIsItemSelected(treeViewItem, true);
+            SetStartItem(treeView, treeViewItem);
+        }
+
+        private static void DeSelectAllItems(TreeView treeView, TreeViewItem treeViewItem)
+        {
+            if (treeView != null)
+            {
+                for (int i = 0; i < treeView.Items.Count; i++)
+                {
+                    var item = treeView.ItemContainerGenerator.ContainerFromIndex(i) as TreeViewItem;
+                    if (item != null)
+                    {
+                        SetIsItemSelected(item, false);
+                        DeSelectAllItems(null, item);
+                    }
+                }
+            }
+            else
+            {
+                for (int i = 0; i < treeViewItem.Items.Count; i++)
+                {
+                    var item = treeViewItem.ItemContainerGenerator.ContainerFromIndex(i) as TreeViewItem;
+                    if (item != null)
+                    {
+                        SetIsItemSelected(item, false);
+                        DeSelectAllItems(null, item);
+                    }
+                }
+            }
+        }
+
+        private static TreeView FindTreeView(DependencyObject dependencyObject)
+        {
+            if (dependencyObject == null)
+            {
+                return null;
+            }
+
+            var treeView = dependencyObject as TreeView;
+
+            return treeView ?? FindTreeView(VisualTreeHelper.GetParent(dependencyObject));
+        }
+
+        private static void SelectMultipleItemsRandomly(TreeView treeView, TreeViewItem treeViewItem)
+        {
+            SetIsItemSelected(treeViewItem, !GetIsItemSelected(treeViewItem));
+            if (GetStartItem(treeView) == null || Keyboard.Modifiers == ModifierKeys.Control)
+            {
+                if (GetIsItemSelected(treeViewItem))
+                {
+                    SetStartItem(treeView, treeViewItem);
+                }
+            }
+            else
+            {
+                if (GetSelectedItems(treeView).Count == 0)
+                {
+                    SetStartItem(treeView, null);
+                }
+            }
+        }
+
+        private static void SelectMultipleItemsContinuously(TreeView treeView, TreeViewItem treeViewItem, bool shiftControl = false)
+        {
+            TreeViewItem startItem = GetStartItem(treeView);
+            if (startItem != null)
+            {
+                if (startItem == treeViewItem)
+                {
+                    SelectSingleItem(treeView, treeViewItem);
+                    return;
+                }
+
+                ICollection<TreeViewItem> allItems = new List<TreeViewItem>();
+                GetAllItems(treeView, null, allItems);
+                //DeSelectAllItems(treeView, null);
+                bool isBetween = false;
+                foreach (var item in allItems)
+                {
+                    if (item == treeViewItem || item == startItem)
+                    {
+                        // toggle to true if first element is found and
+                        // back to false if last element is found
+                        isBetween = !isBetween;
+
+                        // set boundary element
+                        SetIsItemSelected(item, true);
+                        continue;
+                    }
+
+                    if (isBetween)
+                    {
+                        SetIsItemSelected(item, true);
+                        continue;
+                    }
+
+                    if (!shiftControl)
+                        SetIsItemSelected(item, false);
+                }
+            }
+        }
+
+        private static void GetAllItems(TreeView treeView, TreeViewItem treeViewItem, ICollection<TreeViewItem> allItems)
+        {
+            if (treeView != null)
+            {
+                for (int i = 0; i < treeView.Items.Count; i++)
+                {
+                    var item = treeView.ItemContainerGenerator.ContainerFromIndex(i) as TreeViewItem;
+                    if (item != null)
+                    {
+                        allItems.Add(item);
+                        GetAllItems(null, item, allItems);
+                    }
+                }
+            }
+            else
+            {
+                for (int i = 0; i < treeViewItem.Items.Count; i++)
+                {
+                    var item = treeViewItem.ItemContainerGenerator.ContainerFromIndex(i) as TreeViewItem;
+                    if (item != null)
+                    {
+                        allItems.Add(item);
+                        GetAllItems(null, item, allItems);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/PackageExplorer/PackageViewer.xaml
+++ b/PackageExplorer/PackageViewer.xaml
@@ -342,7 +342,7 @@
                             <TextBlock Text="{x:Static self:Resources.Dialog_PublisherLabel}" Style="{StaticResource DetailMetadataLabelStyle}" />
 
                             <ContentPresenter Content="{Binding PublisherSignature, Mode=OneWay}" />
-                            
+
                         </StackPanel>
 
                         <!-- Repository -->
@@ -353,7 +353,7 @@
                             <ContentPresenter Content="{Binding RepositorySignature, Mode=OneWay}" />
 
                         </StackPanel>
-  
+
                         <!-- Validation -->
                         <StackPanel Style="{StaticResource DetailMetadataStyle}" 
                                     Visibility="{Binding IsSigned, Converter={StaticResource boolToVis}}">
@@ -503,7 +503,7 @@
 
                         <ItemsControl x:Name="PackageAssemblyReferences" Margin="25,5,0,0" ItemsSource="{Binding PackageAssemblyReferences, Converter={StaticResource ReferenceSetConverter}}">
                         </ItemsControl>
-                       
+
                     </StackPanel>
                 </ScrollViewer>
             </DataTemplate>
@@ -572,6 +572,119 @@
 
                 </HierarchicalDataTemplate.Triggers>
             </HierarchicalDataTemplate>
+
+            <Style x:Key="TreeViewItemFocusVisual">
+                <Setter Property="Control.Template">
+                    <Setter.Value>
+                        <ControlTemplate>
+                            <Rectangle/>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+            <SolidColorBrush x:Key="TreeViewItem.TreeArrow.Static.Checked.Fill" Color="#FF595959"/>
+            <SolidColorBrush x:Key="TreeViewItem.TreeArrow.Static.Checked.Stroke" Color="#FF262626"/>
+            <SolidColorBrush x:Key="TreeViewItem.TreeArrow.MouseOver.Stroke" Color="#FF27C7F7"/>
+            <SolidColorBrush x:Key="TreeViewItem.TreeArrow.MouseOver.Fill" Color="#FFCCEEFB"/>
+            <SolidColorBrush x:Key="TreeViewItem.TreeArrow.MouseOver.Checked.Stroke" Color="#FF1CC4F7"/>
+            <SolidColorBrush x:Key="TreeViewItem.TreeArrow.MouseOver.Checked.Fill" Color="#FF82DFFB"/>
+            <PathGeometry x:Key="TreeArrow" Figures="M0,0 L0,6 L6,0 z"/>
+            <SolidColorBrush x:Key="TreeViewItem.TreeArrow.Static.Fill" Color="#FFFFFFFF"/>
+            <SolidColorBrush x:Key="TreeViewItem.TreeArrow.Static.Stroke" Color="#FF818181"/>
+            <Style x:Key="ExpandCollapseToggleStyle" TargetType="{x:Type ToggleButton}">
+                <Setter Property="Focusable" Value="False"/>
+                <Setter Property="Width" Value="16"/>
+                <Setter Property="Height" Value="16"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="{x:Type ToggleButton}">
+                            <Border Background="Transparent" Height="16" Padding="5,5,5,5" Width="16">
+                                <Path x:Name="ExpandPath" Data="{StaticResource TreeArrow}" Fill="{StaticResource TreeViewItem.TreeArrow.Static.Fill}" Stroke="{StaticResource TreeViewItem.TreeArrow.Static.Stroke}">
+                                    <Path.RenderTransform>
+                                        <RotateTransform Angle="135" CenterY="3" CenterX="3"/>
+                                    </Path.RenderTransform>
+                                </Path>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsChecked" Value="True">
+                                    <Setter Property="RenderTransform" TargetName="ExpandPath">
+                                        <Setter.Value>
+                                            <RotateTransform Angle="180" CenterY="3" CenterX="3"/>
+                                        </Setter.Value>
+                                    </Setter>
+                                    <Setter Property="Fill" TargetName="ExpandPath" Value="{StaticResource TreeViewItem.TreeArrow.Static.Checked.Fill}"/>
+                                    <Setter Property="Stroke" TargetName="ExpandPath" Value="{StaticResource TreeViewItem.TreeArrow.Static.Checked.Stroke}"/>
+                                </Trigger>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter Property="Stroke" TargetName="ExpandPath" Value="{StaticResource TreeViewItem.TreeArrow.MouseOver.Stroke}"/>
+                                    <Setter Property="Fill" TargetName="ExpandPath" Value="{StaticResource TreeViewItem.TreeArrow.MouseOver.Fill}"/>
+                                </Trigger>
+                                <MultiTrigger>
+                                    <MultiTrigger.Conditions>
+                                        <Condition Property="IsMouseOver" Value="True"/>
+                                        <Condition Property="IsChecked" Value="True"/>
+                                    </MultiTrigger.Conditions>
+                                    <Setter Property="Stroke" TargetName="ExpandPath" Value="{StaticResource TreeViewItem.TreeArrow.MouseOver.Checked.Stroke}"/>
+                                    <Setter Property="Fill" TargetName="ExpandPath" Value="{StaticResource TreeViewItem.TreeArrow.MouseOver.Checked.Fill}"/>
+                                </MultiTrigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+            <Style TargetType="{x:Type TreeViewItem}" x:Key="MyTreeViewItemStyle">
+                <Setter Property="Background" Value="Transparent"/>
+                <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
+                <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
+                <Setter Property="Padding" Value="1,0,0,0"/>
+                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+                <Setter Property="FocusVisualStyle" Value="{StaticResource TreeViewItemFocusVisual}"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="{x:Type TreeViewItem}">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition MinWidth="19" Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition/>
+                                </Grid.RowDefinitions>
+                                <ToggleButton x:Name="Expander" ClickMode="Press" IsChecked="{Binding IsExpanded, RelativeSource={RelativeSource TemplatedParent}}" Style="{StaticResource ExpandCollapseToggleStyle}"/>
+                                <Border x:Name="Bd" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" Grid.Column="1" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="true">
+                                    <ContentPresenter x:Name="PART_Header" ContentSource="Header" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                </Border>
+                                <ItemsPresenter x:Name="ItemsHost" Grid.ColumnSpan="2" Grid.Column="1" Grid.Row="1"/>
+                            </Grid>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsExpanded" Value="false">
+                                    <Setter Property="Visibility" TargetName="ItemsHost" Value="Collapsed"/>
+                                </Trigger>
+                                <Trigger Property="HasItems" Value="false">
+                                    <Setter Property="Visibility" TargetName="Expander" Value="Hidden"/>
+                                </Trigger>
+                                <Trigger Property="IsEnabled" Value="false">
+                                    <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+                <Style.Triggers>
+                    <Trigger Property="VirtualizingStackPanel.IsVirtualizing" Value="true">
+                        <Setter Property="ItemsPanel">
+                            <Setter.Value>
+                                <ItemsPanelTemplate>
+                                    <VirtualizingStackPanel/>
+                                </ItemsPanelTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+            
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -654,9 +767,9 @@
         
         <!-- package content tree view -->
         <HeaderedContentControl Margin="1,0,0,0" Grid.Column="2" Header="Package contents">
-            <TreeView x:Name="PackagesTreeView" ItemsSource="{Binding PackageParts}" BorderThickness="0" Margin="0,4,0,0" DragOver="OnTreeViewItemDragOver" Drop="OnTreeViewItemDrop" SelectedItemChanged="OnTreeViewSelectedItemChanged" PreviewMouseRightButtonDown="TreeView_PreviewMouseRightButtonDown">
+            <controls:MultiSelectTreeView x:Name="PackagesTreeView" ItemsSource="{Binding PackageParts}" SelectedItems="{Binding SelectedItems}" BorderThickness="0" Margin="0,4,0,0" DragOver="OnTreeViewItemDragOver" Drop="OnTreeViewItemDrop" SelectedItemChanged="OnTreeViewSelectedItemChanged" PreviewMouseRightButtonDown="TreeView_PreviewMouseRightButtonDown">
                 <TreeView.ItemContainerStyle>
-                    <Style TargetType="{x:Type TreeViewItem}">
+                    <Style TargetType="{x:Type TreeViewItem}" BasedOn="{StaticResource MyTreeViewItemStyle}">
                         <EventSetter Event="MouseDoubleClick" Handler="OnTreeViewItemDoubleClick" />
                         <EventSetter Event="DragOver" Handler="OnTreeViewItemDragOver" />
                         <EventSetter Event="Drop" Handler="OnTreeViewItemDrop" />
@@ -664,8 +777,15 @@
                         <EventSetter Event="MouseMove" Handler="PackagesTreeViewItem_MouseMove" />
                         <EventSetter Event="PreviewMouseLeftButtonUp" Handler="PackagesTreeViewItem_PreviewMouseLeftButtonUp" />
                         <Setter Property="IsExpanded" Value="{Binding IsExpanded, FallbackValue=False}" />
-                        <Setter Property="IsSelected" Value="{Binding IsSelected}" />
+                        <Setter Property="controls:MultiSelectTreeView.IsItemSelected" Value="{Binding IsSelected, Mode=TwoWay}" />
                         <Setter Property="AllowDrop" Value="True" />
+
+                        <Style.Triggers>
+                            <Trigger Property="controls:MultiSelectTreeView.IsItemSelected" Value="True">
+                                <Setter Property="Background" Value="SkyBlue" />
+                            </Trigger>
+                        </Style.Triggers>
+                        
                     </Style>
                 </TreeView.ItemContainerStyle>
 
@@ -717,7 +837,7 @@
                     <CommandBinding Command="Copy" Executed="OnTreeViewItemCopy" />
                     <CommandBinding Command="Paste" Executed="OnTreeViewItemPaste" CanExecute="OnTreeViewItemCanPaste" />
                 </TreeView.CommandBindings>
-            </TreeView>
+            </controls:MultiSelectTreeView>
         </HeaderedContentControl>
 
         <GridSplitter Grid.Column="2" Grid.Row="1" Visibility="{Binding ShowContentViewer, Converter={StaticResource boolToVis}, FallbackValue=Collapsed}" ResizeBehavior="PreviousAndNext" Height="4" Margin="0,-2,0,0" HorizontalAlignment="Stretch" VerticalAlignment="Bottom" />

--- a/PackageExplorer/PackageViewer.xaml.cs
+++ b/PackageExplorer/PackageViewer.xaml.cs
@@ -352,7 +352,7 @@ namespace PackageExplorer
                     break;
                 }
             }
-            if (element is TreeViewItem item)
+            if (element is TreeViewItem)
             {
                 if (DataContext is PackageViewModel model)
                 {

--- a/PackageExplorer/PackageViewer.xaml.cs
+++ b/PackageExplorer/PackageViewer.xaml.cs
@@ -303,6 +303,16 @@ namespace PackageExplorer
             if (DataContext is PackageViewModel model)
             {
                 model.SelectedItem = PackagesTreeView.SelectedItem;
+
+                for (var i = model.SelectedItems.Count - 1; i >= 0; i--)
+                {
+                    // get rid of null objects
+                    var item = model.SelectedItems[i];
+                    if (!(item is PackagePart))
+                    {
+                        model.SelectedItems.RemoveAt(i);
+                    }
+                }
             }
         }
 
@@ -342,10 +352,16 @@ namespace PackageExplorer
                     break;
                 }
             }
-            if (element is TreeViewItem)
+            if (element is TreeViewItem item)
             {
-                element.Focus();
-                e.Handled = true;
+                if (DataContext is PackageViewModel model)
+                {
+                    if (model.SelectedItems.Count <= 1)
+                    {
+                        element.Focus();
+                        e.Handled = true;
+                    }
+                }
             }
         }
 

--- a/PackageExplorer/PackageViewer.xaml.cs
+++ b/PackageExplorer/PackageViewer.xaml.cs
@@ -303,16 +303,6 @@ namespace PackageExplorer
             if (DataContext is PackageViewModel model)
             {
                 model.SelectedItem = PackagesTreeView.SelectedItem;
-
-                for (var i = model.SelectedItems.Count - 1; i >= 0; i--)
-                {
-                    // get rid of null objects
-                    var item = model.SelectedItems[i];
-                    if (!(item is PackagePart))
-                    {
-                        model.SelectedItems.RemoveAt(i);
-                    }
-                }
             }
         }
 

--- a/PackageViewModel/PackageViewModel.cs
+++ b/PackageViewModel/PackageViewModel.cs
@@ -246,8 +246,8 @@ namespace PackageExplorerViewModel
             {
                 if (!_selectedItems.Contains(value))
                 {
-                    _selectedItems.Add(value);
-                    OnPropertyChanged("SelectedItems");
+                    _selectedItems = value;
+                    OnPropertyChanged(nameof(SelectedItems));
                     ((ViewContentCommand)ViewContentCommand).RaiseCanExecuteChanged();
                     CommandManager.InvalidateRequerySuggested();
                 }
@@ -622,10 +622,7 @@ namespace PackageExplorerViewModel
         {
             DiagnosticsClient.TrackEvent("PackageViewModel_DeleteContentExecute");
 
-            // Null objects are put sometimes into List, so to not count them
-            //var moreValuesToDelete = SelectedItems.Select(p => ).Count();
-
-            if (SelectedItems.Count() <= 1)
+            if (SelectedItems.Count <= 1)
             {
                 if ((parameter ?? SelectedItem) is PackagePart file)
                 {

--- a/PackageViewModel/PackageViewModel.cs
+++ b/PackageViewModel/PackageViewModel.cs
@@ -60,7 +60,7 @@ namespace PackageExplorerViewModel
         private ICommand? _removeSignatureCommand;
         private FileSystemWatcher? _watcher;
 
-        private List<object?> _selectedItems = new List<object?>();        
+        private readonly List<object?> _selectedItems = new List<object?>();        
 
         #endregion
 
@@ -242,16 +242,6 @@ namespace PackageExplorerViewModel
         public List<object?> SelectedItems
         {
             get { return _selectedItems; }
-            set
-            {
-                if (!_selectedItems.Contains(value))
-                {
-                    _selectedItems = value;
-                    OnPropertyChanged(nameof(SelectedItems));
-                    ((ViewContentCommand)ViewContentCommand).RaiseCanExecuteChanged();
-                    CommandManager.InvalidateRequerySuggested();
-                }
-            }
         }
 
         public string PackagePath

--- a/PackageViewModel/PackageViewModel.cs
+++ b/PackageViewModel/PackageViewModel.cs
@@ -656,10 +656,6 @@ namespace PackageExplorerViewModel
                         file.Delete(false);
                         continue;
                     }
-                    if (SelectedItems[i] == null)
-                    {
-                        SelectedItems.RemoveAt(i);
-                    }
                 }
             }
         }

--- a/PackageViewModel/Resources.Designer.cs
+++ b/PackageViewModel/Resources.Designer.cs
@@ -157,6 +157,17 @@ namespace PackageExplorerViewModel
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Are you sure you want to delete selected entries?.
+        /// </summary>
+        public static string ConfirmToDeleteMultipleContent
+        {
+            get
+            {
+                return ResourceManager.GetString("ConfirmToDeleteMultipleContent", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Deleted file or folder is not recoverable..
         /// </summary>
         public static string ConfirmToDeleteContent_Title
@@ -164,6 +175,18 @@ namespace PackageExplorerViewModel
             get
             {
                 return ResourceManager.GetString("ConfirmToDeleteContent_Title", resourceCulture);
+            }
+        }
+
+
+        /// <summary>
+        ///   Looks up a localized string similar to Deleted files or folders are not recoverable..
+        /// </summary>
+        public static string ConfirmToDeleteMultipleContent_Title
+        {
+            get
+            {
+                return ResourceManager.GetString("ConfirmToDeleteMultipleContent_Title", resourceCulture);
             }
         }
 

--- a/PackageViewModel/Resources.resx
+++ b/PackageViewModel/Resources.resx
@@ -144,6 +144,12 @@
   <data name="ConfirmToDeleteContent_Title" xml:space="preserve">
     <value>Deleted file or folder is not recoverable.</value>
   </data>
+  <data name="ConfirmToDeleteMultipleContent" xml:space="preserve">
+    <value>Are you sure you want to delete selected entries?</value>
+  </data>
+  <data name="ConfirmToDeleteMultipleContent_Title" xml:space="preserve">
+    <value>Deleted files or folders are not recoverable.</value>
+  </data>
   <data name="ConfirmToDeletePlugin" xml:space="preserve">
     <value>Are you sure you want to delete this plugin?</value>
   </data>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -180,16 +180,16 @@ stages:
               arguments: install --tool-path . SignClient
             displayName: Install SignTool tool
 
-          - script: |
-              SignClient "Sign" ^
-              --baseDirectory "$(Pipeline.Workspace)\ToSign" ^
-              --input "**/*.{appxbundle,appinstaller,zip,nupkg}" ^
-              --config "$(Pipeline.Workspace)\SigningScripts\appsettings.json" ^
-              --filter "$(Pipeline.Workspace)\SigningScripts\filelist.txt" ^
-              --user "$(SignClientUser)" ^
-              --secret "$(SignClientSecret)" ^
-              --name "NuGet Package Explorer" ^
-              --description "NuGet Package Explorer" ^
+          - pwsh: |
+              .\SignClient "Sign" `
+              --baseDirectory "$(Pipeline.Workspace)\ToSign" `
+              --input "**/*.{appxbundle,appinstaller,zip,nupkg}" `
+              --config "$(Pipeline.Workspace)\SigningScripts\appsettings.json" `
+              --filter "$(Pipeline.Workspace)\SigningScripts\filelist.txt" `
+              --user "$(SignClientUser)" `
+              --secret "$(SignClientSecret)" `
+              --name "NuGet Package Explorer" `
+              --description "NuGet Package Explorer" `
               --descriptionUrl "https://github.com/NuGetPackageExplorer/NuGetPackageExplorer"
             displayName: Authenticode Sign artifacts
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -185,7 +185,7 @@ stages:
               --baseDirectory "$(Pipeline.Workspace)\ToSign" `
               --input "**/*.{appxbundle,appinstaller,zip,nupkg}" `
               --config "$(Pipeline.Workspace)\SigningScripts\appsettings.json" `
-              --filter "$(Pipeline.Workspace)\SigningScripts\filelist.txt" `
+              --filelist "$(Pipeline.Workspace)\SigningScripts\filelist.txt" `
               --user "$(SignClientUser)" `
               --secret "$(SignClientSecret)" `
               --name "NuGet Package Explorer" `


### PR DESCRIPTION
-> usage of MultiSelectTreeView extension of basic TreeView element
-> overriden TreeView style for better selection of items (PackageViewer.xaml)
-> adjusted delete functionality for multi selection

Multi selection in Package Content List was implemented. I was thinking also to disable other options (allow just delete) in ContextMenu's, but I was unable to bind it well into model (if it will be requested, I can work it out). I focused on availability of multiselection for delete purposes, as was described in Issue (https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/issues/805).