### PR TITLE
show deprecated packages in package list details

### DIFF
--- a/Core/Packages/DeprecationInfo.cs
+++ b/Core/Packages/DeprecationInfo.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using NuGet.Versioning;
+
+namespace NuGetPe
+{
+    public class DeprecationInfo
+    {
+        public string? Message { get; set; }
+#pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+        public IEnumerable<string> Reasons { get; set; }
+#pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+        public AlternatePackageInfo? AlternatePackageInfo { get; set; }
+    }
+
+    public class AlternatePackageInfo
+    {
+#pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+        public string Id { get; set; }
+#pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+#pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+        public VersionRange Range { get; set; }
+#pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+    }
+}

--- a/Core/Packages/PackageInfo.cs
+++ b/Core/Packages/PackageInfo.cs
@@ -5,7 +5,7 @@ using NuGet.Versioning;
 namespace NuGetPe
 {
     /// <summary>
-    /// Encapsulates relevant Nuget package information
+    /// Encapsulates relevant NuGet package information.
     /// </summary>
     public class PackageInfo
     {
@@ -21,12 +21,12 @@ namespace NuGetPe
         }
 
         /// <summary>
-        /// Gets the core package identity
+        /// Gets the core package identity.
         /// </summary>
         public PackageIdentity Identity { get; }
 
         /// <summary>
-        /// Gets the name of the package
+        /// Gets the name of the package.
         /// </summary>
         public string Id => Identity.Id;
 
@@ -41,52 +41,52 @@ namespace NuGetPe
         public string Version => SemanticVersion.ToFullString();
 
         /// <summary>
-        /// Gets or sets the full package description
+        /// Gets or sets the full package description.
         /// </summary>
         public string? Description { get; set; }
 
         /// <summary>
-        /// Gets or sets the short description of the package
+        /// Gets or sets the short description of the package.
         /// </summary>
         public string? Summary { get; set; }
 
         /// <summary>
-        /// Gets or sets the comma-separated list of packages authors
+        /// Gets or sets the comma-separated list of packages authors.
         /// </summary>
         public string? Authors { get; set; }
 
         /// <summary>
-        /// Gets or sets the number of package downloads
+        /// Gets or sets the number of package downloads.
         /// </summary>
         public int? DownloadCount { get; set; }
 
         /// <summary>
-        /// Gets or sets the time of the packages publishing
+        /// Gets or sets the time of the packages publishing.
         /// </summary>
         public DateTimeOffset? Published { get; set; }
 
         /// <summary>
-        /// Gets or sets the url to the package icon
+        /// Gets or sets the url to the package icon.
         /// </summary>
         public string? IconUrl { get; set; }
 
         /// <summary>
-        /// Gets or sets the url to the package license information
+        /// Gets or sets the url to the package license information.
         /// </summary>
         public string? LicenseUrl { get; set; }
 
         /// <summary>
-        /// Gets or sets the url to the package website
+        /// Gets or sets the url to the package website.
         /// </summary>
         public string? ProjectUrl { get; set; }
 
         /// <summary>
-        /// Gets or sets the space-delimited list of tags and keywords that describe the package
+        /// Gets or sets the space-delimited list of tags and keywords that describe the package.
         /// </summary>
         public string? Tags { get; set; }
 
         /// <summary>
-        /// Gets or sets the url to report abuse of the package
+        /// Gets or sets the url to report abuse of the package.
         /// </summary>
         public string? ReportAbuseUrl { get; set; }
 
@@ -101,7 +101,12 @@ namespace NuGetPe
         public bool IsRemotePackage { get; set; }
 
         /// <summary>
-        /// Gets whether or not the package is currently published
+        /// Gets or sets whether or not the package is deprecated.
+        /// </summary>
+        public bool IsDeprecated { get; set; }
+
+        /// <summary>
+        /// Gets whether or not the package is currently published.
         /// </summary>
         public bool IsUnlisted
         {

--- a/Core/Packages/PackageInfo.cs
+++ b/Core/Packages/PackageInfo.cs
@@ -101,9 +101,9 @@ namespace NuGetPe
         public bool IsRemotePackage { get; set; }
 
         /// <summary>
-        /// Gets or sets whether or not the package is deprecated.
+        /// Gets or sets set package deprecation info.
         /// </summary>
-        public bool IsDeprecated { get; set; }
+        public DeprecationInfo? DeprecationInfo { get; set; }
 
         /// <summary>
         /// Gets whether or not the package is currently published.

--- a/PackageExplorer/PackageChooser/PackageDetailControl.xaml
+++ b/PackageExplorer/PackageChooser/PackageDetailControl.xaml
@@ -63,7 +63,7 @@
                     </Grid.ColumnDefinitions>
 
                     <!-- Deprecated -->
-                    <Label Grid.Row="0" Grid.Column="0" Padding="0" Visibility="{Binding SelectedPackage.IsDeprecated, Converter={StaticResource boolToVis}}">
+                    <Label Grid.Row="0" Grid.Column="0" Padding="0" Visibility="{Binding SelectedPackage.DeprecationInfo, Converter={StaticResource NullToVisibilityConverter}}">
                         <Label.Content>
                             <TextBlock>
                                 <ContentControl Content="{StaticResource StatusSecurityWarningIcon}" />
@@ -71,7 +71,22 @@
                             </TextBlock>
                         </Label.Content>
                     </Label>
-                    
+                    <Grid Grid.Row="0" Grid.Column="1" Visibility="{Binding SelectedPackage.DeprecationInfo, Converter={StaticResource NullToVisibilityConverter}}">
+                        <Grid.RowDefinitions>
+                            <RowDefinition />
+                            <RowDefinition />
+                        </Grid.RowDefinitions>
+                        <!-- Deprecation Message -->
+                        <TextBlock Grid.Row="0" Text="{Binding SelectedPackage.DeprecationInfo.Message, Mode=OneWay}" Visibility="{Binding SelectedPackage.DeprecationInfo.Message, Converter={StaticResource NullToVisibilityConverter}}" />
+                        <!-- Deprecation Alternate Package -->
+                        <TextBlock Grid.Row="1" Visibility="{Binding SelectedPackage.DeprecationInfo.AlternatePackageInfo, Converter={StaticResource NullToVisibilityConverter}, ConverterParameter='test'}">
+                            <Run Text="{x:Static self:Resources.PackageChooser_AlternatePackage}"/>
+                            <Hyperlink Command="{Binding OpenAlternatePackageCommand}" CommandParameter="{Binding SelectedPackage.DeprecationInfo.AlternatePackageInfo.Id}">
+                                <Run Text="{Binding SelectedPackage.DeprecationInfo.AlternatePackageInfo.Id}"/>
+                            </Hyperlink>
+                        </TextBlock>
+                    </Grid>
+
                     <!-- Version -->
                     <Label Grid.Row="1" Grid.Column="0" Content="{x:Static self:Resources.PackageChooser_DetailVersion}" />
                     <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding SelectedPackage.Version, Mode=OneWay}" />

--- a/PackageExplorer/PackageChooser/PackageDetailControl.xaml
+++ b/PackageExplorer/PackageChooser/PackageDetailControl.xaml
@@ -67,7 +67,7 @@
                         <Label.Content>
                             <TextBlock>
                                 <ContentControl Content="{StaticResource StatusSecurityWarningIcon}" />
-                                <Run BaselineAlignment="Center">Deprecated</Run>
+                                <Run BaselineAlignment="Center" Text="{x:Static self:Resources.PackageChooser_Deprecated}" />
                             </TextBlock>
                         </Label.Content>
                     </Label>

--- a/PackageExplorer/PackageChooser/PackageDetailControl.xaml
+++ b/PackageExplorer/PackageChooser/PackageDetailControl.xaml
@@ -55,51 +55,62 @@
                         <RowDefinition/>
                         <RowDefinition/>
                         <RowDefinition/>
+                        <RowDefinition/>
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="0.4*"/>
                         <ColumnDefinition/>
                     </Grid.ColumnDefinitions>
 
+                    <!-- Deprecated -->
+                    <Label Grid.Row="0" Grid.Column="0" Padding="0" Visibility="{Binding SelectedPackage.IsDeprecated, Converter={StaticResource boolToVis}}">
+                        <Label.Content>
+                            <TextBlock>
+                                <ContentControl Content="{StaticResource StatusSecurityWarningIcon}" />
+                                <Run BaselineAlignment="Center">Deprecated</Run>
+                            </TextBlock>
+                        </Label.Content>
+                    </Label>
+                    
                     <!-- Version -->
-                    <Label Grid.Row="0" Grid.Column="0" Content="{x:Static self:Resources.PackageChooser_DetailVersion}" />
-                    <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding SelectedPackage.Version, Mode=OneWay}" />
+                    <Label Grid.Row="1" Grid.Column="0" Content="{x:Static self:Resources.PackageChooser_DetailVersion}" />
+                    <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding SelectedPackage.Version, Mode=OneWay}" />
 
                     <!-- Authors -->
-                    <Label Grid.Row="1" Grid.Column="0" Content="{x:Static self:Resources.PackageChooser_DetailAuthors}" />
-                    <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding SelectedPackage.Authors}" />
+                    <Label Grid.Row="2" Grid.Column="0" Content="{x:Static self:Resources.PackageChooser_DetailAuthors}" />
+                    <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding SelectedPackage.Authors}" />
 
                     <!-- License URL -->
-                    <Label Grid.Row="2" Grid.Column="0" Content="{x:Static self:Resources.PackageChooser_DetailLicense}" />
-                    <TextBlock Grid.Row="2" Grid.Column="1">
+                    <Label Grid.Row="3" Grid.Column="0" Content="{x:Static self:Resources.PackageChooser_DetailLicense}" />
+                    <TextBlock Grid.Row="3" Grid.Column="1">
                         <Hyperlink NavigateUri="{Binding SelectedPackage.LicenseUrl}" RequestNavigate="Hyperlink_OnRequestNavigate">
                             <Run Text="{Binding SelectedPackage.LicenseUrl}"/>
                         </Hyperlink>
                     </TextBlock>
 
                     <!-- Published Date -->
-                    <Label Grid.Row="3" Grid.Column="0" Content="{x:Static self:Resources.PackageChooser_DetailDatePublished}" Visibility="{Binding SelectedPackage.Published, Converter={StaticResource NullToVisibilityConverter}}" />
-                    <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding SelectedPackage.Published, Converter={StaticResource DateTimeOffsetLongDateConverter}}"  Visibility="{Binding SelectedPackage.Published, Converter={StaticResource NullToVisibilityConverter}}" />
+                    <Label Grid.Row="4" Grid.Column="0" Content="{x:Static self:Resources.PackageChooser_DetailDatePublished}" Visibility="{Binding SelectedPackage.Published, Converter={StaticResource NullToVisibilityConverter}}" />
+                    <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding SelectedPackage.Published, Converter={StaticResource DateTimeOffsetLongDateConverter}}"  Visibility="{Binding SelectedPackage.Published, Converter={StaticResource NullToVisibilityConverter}}" />
 
                     <!-- Project URL --> 
-                    <Label Grid.Row="4" Grid.Column="0" Content="{x:Static self:Resources.PackageChooser_DetailProjectUrl}" />
-                    <TextBlock Grid.Row="4" Grid.Column="1">
+                    <Label Grid.Row="5" Grid.Column="0" Content="{x:Static self:Resources.PackageChooser_DetailProjectUrl}" />
+                    <TextBlock Grid.Row="5" Grid.Column="1">
                         <Hyperlink NavigateUri="{Binding SelectedPackage.ProjectUrl}" RequestNavigate="Hyperlink_OnRequestNavigate">
                             <Run Text="{Binding SelectedPackage.ProjectUrl}"/>
                         </Hyperlink>
                     </TextBlock>
 
                      <!-- Report Abuse URL -->
-                    <Label Grid.Row="5" Grid.Column="0" Content="{x:Static self:Resources.PackageChooser_DetailReportAbuse}" />
-                    <TextBlock Grid.Row="5" Grid.Column="1">
+                    <Label Grid.Row="6" Grid.Column="0" Content="{x:Static self:Resources.PackageChooser_DetailReportAbuse}" />
+                    <TextBlock Grid.Row="6" Grid.Column="1">
                         <Hyperlink NavigateUri="{Binding SelectedPackage.ReportAbuseUrl}" RequestNavigate="Hyperlink_OnRequestNavigate">
                             <Run Text="{Binding SelectedPackage.ReportAbuseUrl}" />
                         </Hyperlink>
                     </TextBlock>
 
                      <!-- Tags --> 
-                    <Label Grid.Row="6" Grid.Column="0" Content="{x:Static self:Resources.PackageChooser_DetailTags}" />
-                    <TextBlock Grid.Row="6" Grid.Column="1" Text="{Binding SelectedPackage.Tags}" />
+                    <Label Grid.Row="7" Grid.Column="0" Content="{x:Static self:Resources.PackageChooser_DetailTags}" />
+                    <TextBlock Grid.Row="7" Grid.Column="1" Text="{Binding SelectedPackage.Tags}" />
                 </Grid>
             </StackPanel>
         </Border>

--- a/PackageExplorer/PackageChooser/PackageListItem.xaml
+++ b/PackageExplorer/PackageChooser/PackageListItem.xaml
@@ -28,11 +28,11 @@
                                        Margin="4,0,0,0"
                                        Visibility="{Binding LatestPackageInfo.IsPrefixReserved, Converter={StaticResource boolToVis}}"/>
             <TextBlock HorizontalAlignment="Stretch" Margin="4,0,0,0">
-                                by
-                                <Run Text="{Binding LatestPackageInfo.Authors, Mode=OneWay}"/>
-                                <TextBlock Visibility="{Binding LatestPackageInfo.DownloadCount, Mode=OneWay, Converter={StaticResource NullToVisibilityConverter}}">,</TextBlock>
-                                <Run Text="{Binding LatestPackageInfo.DownloadCount, Mode=OneWay, Converter={StaticResource NumberToStringConverter}}" FontWeight="Bold"/>
-                                <TextBlock Visibility="{Binding LatestPackageInfo.DownloadCount,  Mode=OneWay,Converter={StaticResource NullToVisibilityConverter}}">downloads</TextBlock>
+                by
+                <Run Text="{Binding LatestPackageInfo.Authors, Mode=OneWay}"/>
+                <TextBlock Visibility="{Binding LatestPackageInfo.DownloadCount, Mode=OneWay, Converter={StaticResource NullToVisibilityConverter}}">,</TextBlock>
+                <Run Text="{Binding LatestPackageInfo.DownloadCount, Mode=OneWay, Converter={StaticResource NumberToStringConverter}}" FontWeight="Bold"/>
+                <TextBlock Visibility="{Binding LatestPackageInfo.DownloadCount,  Mode=OneWay,Converter={StaticResource NullToVisibilityConverter}}">downloads</TextBlock>
             </TextBlock>
 
         </StackPanel>
@@ -50,7 +50,8 @@
             </Label.Style>
             <Label.Content>
                 <TextBlock>
-                                    v<Run Text="{Binding LatestPackageInfo.SemanticVersion, Mode=OneWay}"/>
+                    <ContentControl Content="{StaticResource StatusSecurityWarningIcon}" ToolTip="{Binding LatestPackageInfo.DeprecationInfo.Message, Mode=OneWay}" Visibility="{Binding LatestPackageInfo.DeprecationInfo, Converter={StaticResource NullToVisibilityConverter}}" />
+                    <Run BaselineAlignment="Center">v</Run><Run BaselineAlignment="Center" Text="{Binding LatestPackageInfo.SemanticVersion, Mode=OneWay}"/>
                 </TextBlock>
             </Label.Content>
         </Label>

--- a/PackageExplorer/Resources.Designer.cs
+++ b/PackageExplorer/Resources.Designer.cs
@@ -484,7 +484,18 @@ namespace PackageExplorer {
                 return ResourceManager.GetString("PackageChooser_ActionShowAllVersions", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Alternate Package:.
+        /// </summary>
+        public static string PackageChooser_AlternatePackage
+        {
+            get
+            {
+                return ResourceManager.GetString("PackageChooser_AlternatePackage", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Clear search.
         /// </summary>

--- a/PackageExplorer/Resources.Designer.cs
+++ b/PackageExplorer/Resources.Designer.cs
@@ -520,7 +520,18 @@ namespace PackageExplorer {
                 return ResourceManager.GetString("PackageChooser_ColumnHeaderVersion", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Deprecated.
+        /// </summary>
+        public static string PackageChooser_Deprecated
+        {
+            get
+            {
+                return ResourceManager.GetString("PackageChooser_Deprecated", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Author(s):.
         /// </summary>

--- a/PackageExplorer/Resources.resx
+++ b/PackageExplorer/Resources.resx
@@ -272,6 +272,9 @@ Do you want to add '{0}' to the list of package publish sources?</value>
   <data name="PackageChooser_ColumnHeaderVersion" xml:space="preserve">
     <value>Version</value>
   </data>
+  <data name="PackageChooser_Deprecated" xml:space="preserve">
+    <value>Deprecated</value>
+  </data>
   <data name="PackageChooser_DetailAuthors" xml:space="preserve">
     <value>Author(s):</value>
   </data>

--- a/PackageExplorer/Resources.resx
+++ b/PackageExplorer/Resources.resx
@@ -260,6 +260,9 @@ Do you want to add '{0}' to the list of package publish sources?</value>
   <data name="PackageChooser_ActionShowAllVersions" xml:space="preserve">
     <value>show all versions</value>
   </data>
+  <data name="PackageChooser_AlternatePackage" xml:space="preserve">
+    <value>Alternate Package:</value>
+  </data>
   <data name="PackageChooser_ClearSearchButtonTooltip" xml:space="preserve">
     <value>Clear search</value>
   </data>
@@ -273,7 +276,7 @@ Do you want to add '{0}' to the list of package publish sources?</value>
     <value>Version</value>
   </data>
   <data name="PackageChooser_Deprecated" xml:space="preserve">
-    <value>Deprecated</value>
+    <value>Deprecated:</value>
   </data>
   <data name="PackageChooser_DetailAuthors" xml:space="preserve">
     <value>Author(s):</value>


### PR DESCRIPTION
Currently only showing in the package version details, because this is how VS does it on my machine.
See https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/issues/838#issuecomment-552091187

I can also add it to the package list, which would look like this:
![image](https://user-images.githubusercontent.com/4009570/68528022-1a018280-02ee-11ea-86ea-fb2671d69dec.png)

fixes https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/issues/838