### PR TITLE
Package icon

### DIFF
--- a/PackageExplorer/Converters/PackageIconConverter.cs
+++ b/PackageExplorer/Converters/PackageIconConverter.cs
@@ -20,7 +20,7 @@ namespace PackageExplorer
                 {
                     foreach (var file in package.RootFolder.GetFiles())
                     {
-                        if (file.Path == metadata.Icon)
+                        if (string.Equals(file.Path, metadata.Icon, StringComparison.OrdinalIgnoreCase))
                         {
                             var image = new BitmapImage();
                             image.BeginInit();

--- a/PackageExplorer/Converters/PackageIconConverter.cs
+++ b/PackageExplorer/Converters/PackageIconConverter.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media.Imaging;
+using PackageExplorerViewModel;
+
+namespace PackageExplorer
+{
+    public class PackageIconConverter : IValueConverter
+    {
+        #region IValueConverter Members
+
+        public object? Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is PackageViewModel package)
+            {
+                var metadata = package.PackageMetadata;
+
+                if (!string.IsNullOrEmpty(metadata.Icon))
+                {
+                    foreach (var file in package.RootFolder.GetFiles())
+                    {
+                        if (file.Path == metadata.Icon)
+                        {
+                            var image = new BitmapImage();
+                            image.BeginInit();
+                            image.CacheOption = BitmapCacheOption.OnLoad;
+                            image.StreamSource = file.GetStream();
+                            image.EndInit();
+                            return image;
+                        }
+                    }
+
+                }
+
+                return metadata.IconUrl;
+            }
+            return null;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+    }
+}

--- a/PackageExplorer/Converters/PackageIconConverter.cs
+++ b/PackageExplorer/Converters/PackageIconConverter.cs
@@ -6,13 +6,13 @@ using PackageExplorerViewModel;
 
 namespace PackageExplorer
 {
-    public class PackageIconConverter : IValueConverter
+    public class PackageIconConverter : IMultiValueConverter
     {
-        #region IValueConverter Members
+        #region IMultiValueConverter Members
 
-        public object? Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        public object? Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value is PackageViewModel package)
+            if (values?.Length > 1 && values[0] is PackageViewModel package && values[1] is string str && !string.IsNullOrEmpty(str))
             {
                 var metadata = package.PackageMetadata;
 
@@ -33,12 +33,19 @@ namespace PackageExplorer
 
                 }
 
-                return metadata.IconUrl;
+                if (metadata.IconUrl != null)
+                {
+                    var image = new BitmapImage();
+                    image.BeginInit();
+                    image.UriSource = metadata.IconUrl;
+                    image.EndInit();
+                    return image;
+                }
             }
             return null;
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
         {
             throw new NotImplementedException();
         }

--- a/PackageExplorer/PackageMetadataEditor.xaml
+++ b/PackageExplorer/PackageMetadataEditor.xaml
@@ -134,9 +134,9 @@
             <!-- Development Dependency -->
             <CheckBox Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2" VerticalContentAlignment="Center" IsChecked="{Binding PackageMetadata.DevelopmentDependency}" Content="_Development Dependency" Style="{StaticResource CheckBoxStyle}" />
 
-            <!-- IconUrl -->
-            <Label Grid.Row="7" Grid.Column="0" Target="IconUrlBox" Style="{StaticResource LabelStyle}" Content="Icon _Url" />
-            <TextBox Grid.Row="7" Grid.Column="1" x:Name="IconUrlBox" Text="{Binding PackageMetadata.IconUrl, Converter={StaticResource UriConverter}}" />
+            <!-- Icon -->
+            <Label Grid.Row="7" Grid.Column="0" Target="IconBox" Style="{StaticResource LabelStyle}" Content="Icon" />
+            <ComboBox Grid.Row="7" Grid.Column="1" x:Name="IconBox" IsEditable="True" Text="{Binding PackageMetadata.IconOrIconUrl}" ItemsSource="{Binding IconPaths}" Style="{StaticResource ComboBoxStyle}" />
 
             <!-- ProjectUrl -->
             <Label Grid.Row="8" Grid.Column="0" Target="ProjectUrlBox" Style="{StaticResource LabelStyle}" Content="_Project Url" />

--- a/PackageExplorer/PackageViewer.xaml
+++ b/PackageExplorer/PackageViewer.xaml
@@ -321,7 +321,14 @@
                 <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
                     <StackPanel Margin="8">
                         <Border BorderBrush="{StaticResource {x:Static SystemColors.ActiveBorderBrushKey}}" BorderThickness="0.5" HorizontalAlignment="Left" Padding="2" Background="White" Margin="0,0,0,5" ToolTipService.ToolTip="{Binding IconOrIconUrl}" Visibility="{Binding IconOrIconUrl, Converter={StaticResource NullToVisibilityConverter}}">
-                            <Image Source="{Binding ElementName=PackageMetadataViewer, Path=DataContext, Converter={StaticResource PackageIconConverter}}" Width="32" Height="32" Stretch="Fill" StretchDirection="DownOnly" />
+                            <Image Width="32" Height="32" Stretch="Fill" StretchDirection="DownOnly">
+                                <Image.Source>
+                                    <MultiBinding Converter="{StaticResource PackageIconConverter}">
+                                        <Binding ElementName="PackageMetadataViewer" Path="DataContext" />
+                                        <Binding Path="IconOrIconUrl" />
+                                    </MultiBinding>
+                                </Image.Source>
+                            </Image>
                         </Border>
 
                         <!-- Id -->

--- a/PackageExplorer/PackageViewer.xaml
+++ b/PackageExplorer/PackageViewer.xaml
@@ -36,6 +36,7 @@
             <self:NuGetVersionConverter x:Key="NuGetVersionConverter" />
             <self:NuGetVersionPreReleaseConverter x:Key="NuGetVersionPreReleaseConverter" />
             <self:ListToStringConverter x:Key="ListToStringConverter" />
+            <self:PackageIconConverter x:Key="PackageIconConverter" />
 
             <DataTemplate DataType="{x:Type core:PackageDependency}">
                 <TextBlock ToolTip="Open this package from online feed.">
@@ -319,8 +320,8 @@
             <DataTemplate x:Key="PackageDetailTemplate" DataType="{x:Type viewmodel:EditablePackageMetadata}">
                 <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
                     <StackPanel Margin="8">
-                        <Border BorderBrush="{StaticResource {x:Static SystemColors.ActiveBorderBrushKey}}" BorderThickness="0.5" HorizontalAlignment="Left" Padding="2" Background="White" Margin="0,0,0,5" ToolTipService.ToolTip="{Binding IconUrl}" Visibility="{Binding IconUrl, Converter={StaticResource NullToVisibilityConverter}}">
-                            <Image Source="{Binding IconUrl, TargetNullValue={x:Null}}" Width="32" Height="32" Stretch="Fill" StretchDirection="DownOnly" />
+                        <Border BorderBrush="{StaticResource {x:Static SystemColors.ActiveBorderBrushKey}}" BorderThickness="0.5" HorizontalAlignment="Left" Padding="2" Background="White" Margin="0,0,0,5" ToolTipService.ToolTip="{Binding IconOrIconUrl}" Visibility="{Binding IconOrIconUrl, Converter={StaticResource NullToVisibilityConverter}}">
+                            <Image Source="{Binding ElementName=PackageMetadataViewer, Path=DataContext, Converter={StaticResource PackageIconConverter}}" Width="32" Height="32" Stretch="Fill" StretchDirection="DownOnly" />
                         </Border>
 
                         <!-- Id -->
@@ -644,7 +645,7 @@
                     </StackPanel>
                 </Border>
 
-                <ContentControl Grid.Row="1" Content="{Binding PackageMetadata}" ContentTemplate="{StaticResource PackageDetailTemplate}" Visibility="{Binding IsInEditMetadataMode, Converter={StaticResource invertedBoolToVis}, FallbackValue=Collapsed}"></ContentControl>
+                <ContentControl x:Name="PackageMetadataViewer" Grid.Row="1" Content="{Binding PackageMetadata}" ContentTemplate="{StaticResource PackageDetailTemplate}" Visibility="{Binding IsInEditMetadataMode, Converter={StaticResource invertedBoolToVis}, FallbackValue=Collapsed}" />
 
                 <self:PackageMetadataEditor x:Name="PackageMetadataEditor" Grid.Row="1" Margin="4,12,4,7" Visibility="{Binding IsInEditMetadataMode, Converter={StaticResource boolToVis}, FallbackValue=Collapsed}" />
             </Grid>

--- a/PackageViewModel/EditablePackageMetadata.cs
+++ b/PackageViewModel/EditablePackageMetadata.cs
@@ -348,7 +348,30 @@ namespace PackageExplorerViewModel
             }
         }
 
-        public string? IconOrIconUrl => Icon ?? IconUrl?.OriginalString;
+        public string? IconOrIconUrl
+        {
+            get => Icon ?? IconUrl?.OriginalString;
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    Icon = null;
+                    IconUrl = null;
+                }
+
+                if (Uri.TryCreate(value, UriKind.Absolute, out var uri))
+                {
+                    Icon = null;
+                    IconUrl = uri;
+                }
+                else
+                {
+                    Icon = value;
+                    IconUrl = null;
+                }
+                RaisePropertyChange(nameof(IconOrIconUrl));
+            }
+        }
 
         public string? Icon
         {

--- a/PackageViewModel/EditablePackageMetadata.cs
+++ b/PackageViewModel/EditablePackageMetadata.cs
@@ -348,12 +348,14 @@ namespace PackageExplorerViewModel
             }
         }
 
+        public string? IconOrIconUrl => Icon ?? IconUrl?.OriginalString;
+
         public string? Icon
         {
             get => _icon;
             set
             {
-                if(_icon != value)
+                if (_icon != value)
                 {
                     _icon = value;
                     RaisePropertyChange(nameof(Icon));
@@ -549,7 +551,7 @@ namespace PackageExplorerViewModel
         {
             get { return SplitString(Owners); }
         }
-  
+
         IEnumerable<FrameworkAssemblyReference> IPackageMetadata.FrameworkReferences
         {
             get { return FrameworkAssemblies; }

--- a/PackageViewModel/PackageViewModel.cs
+++ b/PackageViewModel/PackageViewModel.cs
@@ -307,6 +307,23 @@ namespace PackageExplorerViewModel
 
         public PackageFolder RootFolder { get; }
 
+        public IEnumerable<string> IconPaths
+        {
+            get
+            {
+                yield return "";
+
+                foreach (var file in RootFolder.GetFiles())
+                {
+                    if (file.Path.EndsWith(".png", StringComparison.OrdinalIgnoreCase) ||
+                        file.Path.EndsWith(".jpg", StringComparison.OrdinalIgnoreCase))
+                    {
+                        yield return file.Path;
+                    }
+                }
+            }
+        }
+
         #region IDisposable Members
 
         public void Dispose()
@@ -1349,6 +1366,7 @@ namespace PackageExplorerViewModel
         internal void NotifyChanges()
         {
             HasEdit = true;
+            OnPropertyChanged(nameof(IconPaths));
         }
 
         public IEnumerable<PackageIssue> Validate()


### PR DESCRIPTION
Package Viewer now displays either the `Icon` or the `IconUrl`. Before and after:
![image](https://user-images.githubusercontent.com/4009570/68532620-ee978b80-031f-11ea-9430-9cc76e69e6d5.png)

In package editing the user can select an existing icon from the package content or specify an URL by hand:
![image](https://user-images.githubusercontent.com/4009570/68532592-7cbf4200-031f-11ea-885f-0f4df9a7c3ef.png)

fixes https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/issues/820