### PR TITLE
Fix providing credentials in feed URL

### DIFF
--- a/PackageExplorer/MefServices/CredentialManager.cs
+++ b/PackageExplorer/MefServices/CredentialManager.cs
@@ -18,7 +18,7 @@ namespace PackageExplorer.MefServices
             _feeds = new List<Tuple<Uri, ICredentials>>();
         }
 
-        public void TryAddUriCredentials(Uri feedUri)
+        private bool TryAddUriCredentials(Uri feedUri, out NetworkCredential credentials)
         {
             // Support username and password in feed URL as specified in RFC 1738
             if (!string.IsNullOrEmpty(feedUri.UserInfo))
@@ -26,9 +26,13 @@ namespace PackageExplorer.MefServices
                 var userInfoSplitted = feedUri.UserInfo.Split(new[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
                 if (userInfoSplitted.Length >= 2)
                 {
-                    Add(new NetworkCredential(userInfoSplitted[0], userInfoSplitted[1]), feedUri);
+                    credentials = new NetworkCredential(userInfoSplitted[0], userInfoSplitted[1]);
+                    Add(credentials, feedUri);
+                    return true;
                 }
             }
+            credentials = null;
+            return false;
         }
 
         public void Add(ICredentials credentials, Uri feedUri)
@@ -51,6 +55,10 @@ namespace PackageExplorer.MefServices
                 if (matchingFeeds.Any())
                 {
                     credentials = matchingFeeds.First().Item2;
+                }
+                else if(TryAddUriCredentials(uri, out var uriCredentials))
+                {
+                    credentials = uriCredentials;
                 }
             }
             return credentials;

--- a/PackageViewModel/Types/ICredentialManager.cs
+++ b/PackageViewModel/Types/ICredentialManager.cs
@@ -5,8 +5,6 @@ namespace PackageExplorerViewModel.Types
 {
     public interface ICredentialManager
     {
-        void TryAddUriCredentials(Uri feedUri);
-
         void Add(ICredentials credentials, Uri feedUri);
 
         ICredentials GetForUri(Uri uri);


### PR DESCRIPTION
Fixes the usage of credentials directly in URL.

E.g. https://myuser:mypass@host.com

this was broken some time ago.