### PR TITLE
Add support to persist credentials in OS credential manager

### DIFF
--- a/PackageExplorer/MefServices/UIServices.cs
+++ b/PackageExplorer/MefServices/UIServices.cs
@@ -478,13 +478,22 @@ namespace PackageExplorer
                 WindowTitle = Resources.Dialog_Title,
                 MainInstruction = "Credentials for " + target,
                 Content = "Enter Personal Access Tokens in the username field.",
-                Target = target
+                Target = target,
+                ShowSaveCheckBox = true, // Allow user to save the credentials to operating system's credential manager
+                ShowUIForSavedCredentials = false // Do not show dialog when credentials can be grabbed from OS credential manager
             };
 
             try
             {
+                // Show dialog or query credential manager
                 if (dialog.ShowDialog())
                 {
+                    // When dialog was shown
+                    if (!dialog.IsStoredCredential)
+                    {
+                        // Save the credentials when save checkbox was checked
+                        dialog.ConfirmCredentials(true);
+                    }
                     networkCredential = dialog.Credentials;
                     return true;
                 }


### PR DESCRIPTION
Credential store is accessed with functionality provided from _Ookii.Dialogs.Wpf.CredentialDialog_.

As suggested in https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/issues/259#issuecomment-361893715

Related to #629 and #259.


If you check "remember me" in the credentials dialog it will be saved to the OS credential manager.
The credential dialog will not show up once the credentials can be retrieved from OS credential manager.
![grafik](https://user-images.githubusercontent.com/2196081/70238839-68c5ff00-176a-11ea-9773-1df620c48a37.png)
