### PR TITLE
Add expand/collapse all buttons

### DIFF
--- a/PackageExplorer/PackageViewer.xaml
+++ b/PackageExplorer/PackageViewer.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl 
+<UserControl 
     x:Class="PackageExplorer.PackageViewer" 
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
@@ -776,71 +776,92 @@
         <GridSplitter Grid.Column="1" Grid.Row="0" Grid.RowSpan="3" ShowsPreview="True" ResizeBehavior="PreviousAndNext" Width="4" HorizontalAlignment="Center" VerticalAlignment="Stretch" />
         
         <!-- package content tree view -->
-        <HeaderedContentControl Margin="1,0,0,0" Grid.Column="2" Header="Package contents">
-            <TreeView x:Name="PackagesTreeView" ItemsSource="{Binding PackageParts}" BorderThickness="0" Margin="0,4,0,0" DragOver="OnTreeViewItemDragOver" Drop="OnTreeViewItemDrop" SelectedItemChanged="OnTreeViewSelectedItemChanged" PreviewMouseRightButtonDown="TreeView_PreviewMouseRightButtonDown">
-                <TreeView.ItemContainerStyle>
-                    <Style TargetType="{x:Type TreeViewItem}">
-                        <EventSetter Event="MouseDoubleClick" Handler="OnTreeViewItemDoubleClick" />
-                        <EventSetter Event="DragOver" Handler="OnTreeViewItemDragOver" />
-                        <EventSetter Event="Drop" Handler="OnTreeViewItemDrop" />
-                        <EventSetter Event="PreviewMouseLeftButtonDown" Handler="PackagesTreeViewItem_PreviewMouseLeftButtonDown" />
-                        <EventSetter Event="MouseMove" Handler="PackagesTreeViewItem_MouseMove" />
-                        <EventSetter Event="PreviewMouseLeftButtonUp" Handler="PackagesTreeViewItem_PreviewMouseLeftButtonUp" />
-                        <Setter Property="IsExpanded" Value="{Binding IsExpanded, FallbackValue=False}" />
-                        <Setter Property="IsSelected" Value="{Binding IsSelected}" />
-                        <Setter Property="AllowDrop" Value="True" />
-                    </Style>
-                </TreeView.ItemContainerStyle>
+        <HeaderedContentControl Margin="1,0,0,0" Padding="0" Grid.Column="2" Header="Package contents">
+            <DockPanel>
+                <!-- Toolbar for package content pane -->
+                <Border DockPanel.Dock="Top" Background="#BCC7D8" Padding="3" BorderBrush="{StaticResource {x:Static SystemColors.ActiveBorderBrushKey}}" BorderThickness="0,1,0,0">
+                    <StackPanel Orientation="Horizontal">
+                        <Button
+                            Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}"
+                            Command="{Binding ExpandAllCommand, Mode=OneWay}"
+                            Margin="2,0,0,0"
+                            ToolTipService.ToolTip="Expand All"
+                            Content="{StaticResource ExpandDownGroupIcon}" />
 
-                <TreeView.ContextMenu>
-                    <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
-                        <MenuItem Header="Add _New File..." Command="{Binding AddNewFileCommand}" CommandParameter="{Binding RootFolder, Mode=OneWay}" Icon="{StaticResource NewItemIcon}" />
-                        <MenuItem Header="_Add Existing File..." Command="{Binding AddContentFileCommand}" CommandParameter="{Binding RootFolder, Mode=OneWay}" Icon="{StaticResource AddItemIcon}" />
-                        <MenuItem Header="Add Ne_w Folder" Command="{Binding AddNewFolderCommand}" CommandParameter="{Binding RootFolder, Mode=OneWay}" Icon="{StaticResource AddFolderIcon}" />
-                        <Separator />
-                        <self:GrayscaleMenuItem Header="Add _Content Folder" Command="{Binding AddContentFolderCommand}" CommandParameter="content">
-                            <self:GrayscaleMenuItem.Icon>
-                                <self:GrayscaleContentPresenter Content="{StaticResource ContentFolderIcon}" />
-                            </self:GrayscaleMenuItem.Icon>
-                        </self:GrayscaleMenuItem>
-                        <self:GrayscaleMenuItem Header="Add _Lib Folder" Command="{Binding AddContentFolderCommand}" CommandParameter="lib">
-                            <self:GrayscaleMenuItem.Icon>
-                                <self:GrayscaleContentPresenter Content="{StaticResource LibFolderIcon}" />
-                            </self:GrayscaleMenuItem.Icon>
-                        </self:GrayscaleMenuItem>
-                        <self:GrayscaleMenuItem Header="Add _Tools Folder" Command="{Binding AddContentFolderCommand}" CommandParameter="tools">
-                            <self:GrayscaleMenuItem.Icon>
-                                <self:GrayscaleContentPresenter Content="{StaticResource ToolsFolderIcon}" />
-                            </self:GrayscaleMenuItem.Icon>
-                        </self:GrayscaleMenuItem>
-                        <self:GrayscaleMenuItem Header="Add _Build Folder" Command="{Binding AddContentFolderCommand}" CommandParameter="build">
-                            <self:GrayscaleMenuItem.Icon>
-                                <self:GrayscaleContentPresenter Content="{StaticResource BuildFolderIcon}" />
-                            </self:GrayscaleMenuItem.Icon>
-                        </self:GrayscaleMenuItem>
-                        <self:GrayscaleMenuItem Header="Add Build_MultiTargeting Folder" Command="{Binding AddContentFolderCommand}" CommandParameter="buildMultiTargeting">
-                            <self:GrayscaleMenuItem.Icon>
-                                <self:GrayscaleContentPresenter Content="{StaticResource BuildFolderIcon}" />
-                            </self:GrayscaleMenuItem.Icon>
-                        </self:GrayscaleMenuItem>
-                        <self:GrayscaleMenuItem Header="Add BuildT_ransitive Folder" Command="{Binding AddContentFolderCommand}" CommandParameter="buildTransitive">
-                            <self:GrayscaleMenuItem.Icon>
-                                <self:GrayscaleContentPresenter Content="{StaticResource BuildFolderIcon}" />
-                            </self:GrayscaleMenuItem.Icon>
-                        </self:GrayscaleMenuItem>
-                        <self:GrayscaleMenuItem Header="Add _Src Folder" Command="{Binding AddContentFolderCommand}" CommandParameter="src">
-                            <self:GrayscaleMenuItem.Icon>
-                                <self:GrayscaleContentPresenter Content="{StaticResource SourceFolderIcon}" />
-                            </self:GrayscaleMenuItem.Icon>
-                        </self:GrayscaleMenuItem>
-                    </ContextMenu>
-                </TreeView.ContextMenu>
+                        <Button
+                            Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}"
+                            Command="{Binding CollapseAllCommand, Mode=OneWay}"
+                            Margin="1,0,0,0"
+                            ToolTipService.ToolTip="Collapse All"
+                            Content="{StaticResource CollapseUpGroupIcon}" />
+                    </StackPanel>
+                </Border>
 
-                <TreeView.CommandBindings>
-                    <CommandBinding Command="Copy" Executed="OnTreeViewItemCopy" />
-                    <CommandBinding Command="Paste" Executed="OnTreeViewItemPaste" CanExecute="OnTreeViewItemCanPaste" />
-                </TreeView.CommandBindings>
-            </TreeView>
+                <TreeView x:Name="PackagesTreeView" ItemsSource="{Binding PackageParts}" BorderThickness="0" Padding="4,8,4,4" DragOver="OnTreeViewItemDragOver" Drop="OnTreeViewItemDrop" SelectedItemChanged="OnTreeViewSelectedItemChanged" PreviewMouseRightButtonDown="TreeView_PreviewMouseRightButtonDown">
+                    <TreeView.ItemContainerStyle>
+                        <Style TargetType="{x:Type TreeViewItem}">
+                            <EventSetter Event="MouseDoubleClick" Handler="OnTreeViewItemDoubleClick" />
+                            <EventSetter Event="DragOver" Handler="OnTreeViewItemDragOver" />
+                            <EventSetter Event="Drop" Handler="OnTreeViewItemDrop" />
+                            <EventSetter Event="PreviewMouseLeftButtonDown" Handler="PackagesTreeViewItem_PreviewMouseLeftButtonDown" />
+                            <EventSetter Event="MouseMove" Handler="PackagesTreeViewItem_MouseMove" />
+                            <EventSetter Event="PreviewMouseLeftButtonUp" Handler="PackagesTreeViewItem_PreviewMouseLeftButtonUp" />
+                            <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay, FallbackValue=False}" />
+                            <Setter Property="IsSelected" Value="{Binding IsSelected}" />
+                            <Setter Property="AllowDrop" Value="True" />
+                        </Style>
+                    </TreeView.ItemContainerStyle>
+
+                    <TreeView.ContextMenu>
+                        <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                            <MenuItem Header="Add _New File..." Command="{Binding AddNewFileCommand}" CommandParameter="{Binding RootFolder, Mode=OneWay}" Icon="{StaticResource NewItemIcon}" />
+                            <MenuItem Header="_Add Existing File..." Command="{Binding AddContentFileCommand}" CommandParameter="{Binding RootFolder, Mode=OneWay}" Icon="{StaticResource AddItemIcon}" />
+                            <MenuItem Header="Add Ne_w Folder" Command="{Binding AddNewFolderCommand}" CommandParameter="{Binding RootFolder, Mode=OneWay}" Icon="{StaticResource AddFolderIcon}" />
+                            <Separator />
+                            <self:GrayscaleMenuItem Header="Add _Content Folder" Command="{Binding AddContentFolderCommand}" CommandParameter="content">
+                                <self:GrayscaleMenuItem.Icon>
+                                    <self:GrayscaleContentPresenter Content="{StaticResource ContentFolderIcon}" />
+                                </self:GrayscaleMenuItem.Icon>
+                            </self:GrayscaleMenuItem>
+                            <self:GrayscaleMenuItem Header="Add _Lib Folder" Command="{Binding AddContentFolderCommand}" CommandParameter="lib">
+                                <self:GrayscaleMenuItem.Icon>
+                                    <self:GrayscaleContentPresenter Content="{StaticResource LibFolderIcon}" />
+                                </self:GrayscaleMenuItem.Icon>
+                            </self:GrayscaleMenuItem>
+                            <self:GrayscaleMenuItem Header="Add _Tools Folder" Command="{Binding AddContentFolderCommand}" CommandParameter="tools">
+                                <self:GrayscaleMenuItem.Icon>
+                                    <self:GrayscaleContentPresenter Content="{StaticResource ToolsFolderIcon}" />
+                                </self:GrayscaleMenuItem.Icon>
+                            </self:GrayscaleMenuItem>
+                            <self:GrayscaleMenuItem Header="Add _Build Folder" Command="{Binding AddContentFolderCommand}" CommandParameter="build">
+                                <self:GrayscaleMenuItem.Icon>
+                                    <self:GrayscaleContentPresenter Content="{StaticResource BuildFolderIcon}" />
+                                </self:GrayscaleMenuItem.Icon>
+                            </self:GrayscaleMenuItem>
+                            <self:GrayscaleMenuItem Header="Add Build_MultiTargeting Folder" Command="{Binding AddContentFolderCommand}" CommandParameter="buildMultiTargeting">
+                                <self:GrayscaleMenuItem.Icon>
+                                    <self:GrayscaleContentPresenter Content="{StaticResource BuildFolderIcon}" />
+                                </self:GrayscaleMenuItem.Icon>
+                            </self:GrayscaleMenuItem>
+                            <self:GrayscaleMenuItem Header="Add BuildT_ransitive Folder" Command="{Binding AddContentFolderCommand}" CommandParameter="buildTransitive">
+                                <self:GrayscaleMenuItem.Icon>
+                                    <self:GrayscaleContentPresenter Content="{StaticResource BuildFolderIcon}" />
+                                </self:GrayscaleMenuItem.Icon>
+                            </self:GrayscaleMenuItem>
+                            <self:GrayscaleMenuItem Header="Add _Src Folder" Command="{Binding AddContentFolderCommand}" CommandParameter="src">
+                                <self:GrayscaleMenuItem.Icon>
+                                    <self:GrayscaleContentPresenter Content="{StaticResource SourceFolderIcon}" />
+                                </self:GrayscaleMenuItem.Icon>
+                            </self:GrayscaleMenuItem>
+                        </ContextMenu>
+                    </TreeView.ContextMenu>
+
+                    <TreeView.CommandBindings>
+                        <CommandBinding Command="Copy" Executed="OnTreeViewItemCopy" />
+                        <CommandBinding Command="Paste" Executed="OnTreeViewItemPaste" CanExecute="OnTreeViewItemCanPaste" />
+                    </TreeView.CommandBindings>
+                </TreeView>
+            </DockPanel>
         </HeaderedContentControl>
 
         <GridSplitter Grid.Column="2" Grid.Row="1" Visibility="{Binding ShowContentViewer, Converter={StaticResource boolToVis}, FallbackValue=Collapsed}" ResizeBehavior="PreviousAndNext" Height="4" Margin="0,-2,0,0" HorizontalAlignment="Stretch" VerticalAlignment="Bottom" />

--- a/PackageExplorer/Xaml/Icons.xaml
+++ b/PackageExplorer/Xaml/Icons.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <Viewbox x:Key="FolderIcon" x:Shared="false" Width="16" Height="16">
         <Rectangle Width="16" Height="16">
@@ -903,4 +903,41 @@
             <Path StrokeThickness="0.8" Stroke="#ff204e8e" StrokeMiterLimit="1.0" Fill="#ff204e8e" Data="F1 M 15.396,0.877 L 34.400,17.384 L 15.396,33.807 L 15.396,25.937 L 0.400,25.937 L 0.400,8.881 L 15.396,8.881 L 15.396,0.877 Z"/>
         </Canvas>
     </Viewbox>
+
+    <Viewbox x:Key="ExpandDownGroupIcon" Width="16" Height="16" x:Shared="false">
+        <Rectangle Width="16" Height="16" Margin="2">
+            <Rectangle.Fill>
+                <DrawingBrush>
+                    <DrawingBrush.Drawing>
+                        <DrawingGroup>
+                            <DrawingGroup.Children>
+                                <GeometryDrawing Brush="#00FFFFFF" Geometry="F1M16,16L0,16 0,0 16,0z" />
+                                <GeometryDrawing Brush="#FFF6F6F6" Geometry="F1M8.0001,5.5861L3.0001,0.5861 0.5861,3.0001 2.5861,5.0001 0.5861,7.0001 8.0001,14.4141 15.4141,7.0001 13.4141,5.0001 15.4141,3.0001 12.9991,0.5861z" />
+                                <GeometryDrawing Brush="#FF424242" Geometry="F1M3,2L2,3 8,9 14,3 13,2 8,7z M3,6L2,7 8,13 14,7 13,6 8,11z" />
+                            </DrawingGroup.Children>
+                        </DrawingGroup>
+                    </DrawingBrush.Drawing>
+                </DrawingBrush>
+            </Rectangle.Fill>
+        </Rectangle>
+    </Viewbox>
+
+    <Viewbox x:Key="CollapseUpGroupIcon" Width="16" Height="16" x:Shared="false">
+        <Rectangle Width="16" Height="16" Margin="2">
+            <Rectangle.Fill>
+                <DrawingBrush>
+                    <DrawingBrush.Drawing>
+                        <DrawingGroup>
+                            <DrawingGroup.Children>
+                                <GeometryDrawing Brush="#00FFFFFF" Geometry="F1M16,16L0,16 0,0 16,0z" />
+                                <GeometryDrawing Brush="#FFF6F6F6" Geometry="F1M0.5859,7.9999L2.5859,9.9999 0.5859,12.0009 2.9999,14.4139 7.9999,9.4139 12.9999,14.4139 15.4139,12.0009 13.4149,9.9999 15.4139,7.9999 7.9999,0.585900000000001z" />
+                                <GeometryDrawing Brush="#FF424242" Geometry="F1M8,8L13,13 14,12 8,6 2,12 3,13z M8,4L13,9 14,8 8,2 2,8 3,9z" />
+                            </DrawingGroup.Children>
+                        </DrawingGroup>
+                    </DrawingBrush.Drawing>
+                </DrawingBrush>
+            </Rectangle.Fill>
+        </Rectangle>
+    </Viewbox>
+
 </ResourceDictionary>

--- a/PackageViewModel/PackageViewModel.cs
+++ b/PackageViewModel/PackageViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
@@ -41,6 +41,8 @@ namespace PackageExplorerViewModel
         private ICommand? _editFileCommand;
         private ICommand? _editMetadataSourceCommand;
         private ICommand? _executePackageCommand;
+        private ICommand? _expandAllCommand;
+        private ICommand? _collapseAllCommand;
         private RelayCommand? _exportCommand;
         private FileEditorViewModel? _fileEditorViewModel;
         private bool _hasEdit;
@@ -1282,6 +1284,44 @@ namespace PackageExplorerViewModel
                 {
                     EditFileCommandExecute(file);
                 }
+            }
+        }
+
+        #endregion
+
+        #region ExpandAllCommand
+
+        public ICommand ExpandAllCommand => _expandAllCommand ??= new RelayCommand(ExpandAllCommandExecute, ExpandAllCommandCanExecute);
+
+        private bool ExpandAllCommandCanExecute()
+        {
+            return PackageParts.Count != 0;
+        }
+
+        private void ExpandAllCommandExecute()
+        {
+            foreach (var folder in RootFolder.GetPackageParts().OfType<PackageFolder>())
+            {
+                folder.IsExpanded = true;
+            }
+        }
+
+        #endregion
+
+        #region CollapseAllCommand
+
+        public ICommand CollapseAllCommand => _collapseAllCommand ??= new RelayCommand(CollapseAllCommandExecute, CollapseAllCommandCanExecute);
+
+        private bool CollapseAllCommandCanExecute()
+        {
+            return PackageParts.Count != 0;
+        }
+
+        private void CollapseAllCommandExecute()
+        {
+            foreach (var folder in RootFolder.GetPackageParts().OfType<PackageFolder>())
+            {
+                folder.IsExpanded = false;
             }
         }
 


### PR DESCRIPTION
Just a quick change to add expand/collapse all buttons, as that's something I wanted to have in this tool.

I added a toolbar to the package contents pane, I hope that's OK. I like it better since it aligns the contents of the two panes vertically.

Here's what it looks like:

![image](https://user-images.githubusercontent.com/7913492/79081316-945e8480-7d1c-11ea-9282-cc3b8dde64d6.png)
