### PR TITLE
Don't hang the UX if converting the pdb hangs

### DIFF
--- a/Core/AssemblyMetadata/AssemblyMetadataReader.cs
+++ b/Core/AssemblyMetadata/AssemblyMetadataReader.cs
@@ -5,11 +5,18 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace NuGetPe.AssemblyMetadata
 {
     public static class AssemblyMetadataReader
     {
+        /// <summary>
+        /// Expects a PE file
+        /// </summary>
+        /// <param name="assemblyPath"></param>
+        /// <returns></returns>
         public static AssemblyMetaDataInfo? ReadMetaData(string assemblyPath)
         {
             if (string.IsNullOrWhiteSpace(assemblyPath))
@@ -46,13 +53,29 @@ namespace NuGetPe.AssemblyMetadata
             return result;
         }
 
-        public static AssemblyDebugData ReadDebugData(Stream? peStream, Stream pdbStream)
+        public static async Task<AssemblyDebugData> ReadDebugData(Stream? peStream, Stream pdbStream)
         {
             if (pdbStream is null)
                 throw new ArgumentNullException(nameof(pdbStream));
 
-            using var reader = new AssemblyDebugParser(peStream, pdbStream);
-            return reader.GetDebugData();
+            try
+            {
+                using var cts = new CancellationTokenSource();
+
+                return await Task.Run(() =>
+                {
+                    cts.CancelAfter(TimeSpan.FromSeconds(10));
+                    using var reader = new AssemblyDebugParser(peStream, pdbStream);
+                    return reader.GetDebugData();
+
+                }, cts.Token).ConfigureAwait(false);
+            }
+            finally
+            {
+                peStream?.Dispose();
+                pdbStream.Dispose();
+            }
+                  
         }
 
         private static void AddAssemblyAttributes(AssemblyMetadataParser parser, AssemblyMetaDataInfo result)

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Types\Types.csproj" />
     <PackageReference Include="AppInsights.WindowsDesktop" Version="2.13.1" />
-    <PackageReference Include="Microsoft.DiaSymReader.Converter" Version="1.1.0-beta2-20203-01" />
+    <PackageReference Include="Microsoft.DiaSymReader.Converter" Version="1.1.0-beta2-20216-01" />
     <PackageReference Include="Microsoft.SymbolStore" Version="1.0.125601" />
     <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.18362.2005" />
     <PackageReference Include="OSVersionHelper" Version="1.0.11" />

--- a/PackageExplorer/MefServices/AssemblyFileViewer.cs
+++ b/PackageExplorer/MefServices/AssemblyFileViewer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using NuGetPackageExplorer.Types;
@@ -28,7 +29,7 @@ namespace PackageExplorer
                 var assemblyMetadata = AssemblyMetadataReader.ReadMetaData(tempFile.FileName);
                 AssemblyDebugDataViewModel? debugDataViewModel = null;
                 if (assemblyMetadata?.DebugData.HasDebugInfo == true)
-                    debugDataViewModel = new AssemblyDebugDataViewModel(assemblyMetadata.DebugData);
+                    debugDataViewModel = new AssemblyDebugDataViewModel(Task.FromResult(assemblyMetadata.DebugData));
 
                 // No debug data to display
                 if (assemblyMetadata != null && debugDataViewModel == null)

--- a/PackageViewModel/AssemblyDebugDataViewModel.cs
+++ b/PackageViewModel/AssemblyDebugDataViewModel.cs
@@ -7,19 +7,40 @@ using NuGetPe.AssemblyMetadata;
 
 namespace PackageExplorerViewModel
 {
-    public class AssemblyDebugDataViewModel
+    public class AssemblyDebugDataViewModel : ViewModelBase
     {
-        private readonly AssemblyDebugData _debugData;
+        private readonly Task<AssemblyDebugData> _debugData;
 
-        public AssemblyDebugDataViewModel(AssemblyDebugData debugData)
+        public AssemblyDebugDataViewModel(Task<AssemblyDebugData> debugData)
         {
             _debugData = debugData ?? throw new ArgumentNullException(nameof(debugData));
-            Sources = CreateSourcesViewModels(debugData);
+            WaitForData();
         }
 
-        public PdbType PdbType => _debugData.PdbType;
+        private async void WaitForData()
+        {
+            try
+            {
+                var debugData = await _debugData;
+                if (debugData != null)
+                {
+                    Sources = CreateSourcesViewModels(debugData);
+                    PdbType = debugData.PdbType;
+                }
 
-        public IReadOnlyList<AssemblyDebugSourceDocumentViewModel> Sources { get; }
+                OnPropertyChanged(nameof(PdbType));
+                OnPropertyChanged(nameof(Sources));
+            }
+            catch
+            {
+
+            }
+            
+        }
+
+        public PdbType PdbType { get; private set; }
+
+        public IReadOnlyList<AssemblyDebugSourceDocumentViewModel>? Sources { get; private set; }
 
         private static IReadOnlyList<AssemblyDebugSourceDocumentViewModel> CreateSourcesViewModels(AssemblyDebugData debugData)
         {


### PR DESCRIPTION
Partially addresses #976 so that the UX won't freeze if you try to open this particular pdb file.

Seems to be an issue deeper down https://github.com/dotnet/symreader-converter/issues/173