### PR TITLE
set certificate to null to prevent application crash because of doubl…

### DIFF
--- a/PackageViewModel/SignPackageViewModel.cs
+++ b/PackageViewModel/SignPackageViewModel.cs
@@ -464,6 +464,7 @@ namespace PackageExplorerViewModel
             _certificateValidationTimer?.Dispose();
             _certificateValidationSemaphore?.Dispose();
             _certificate?.Dispose();
+            _certificate = null;
         }
     }
 }


### PR DESCRIPTION
…e disposing

While trying to reproduce #985 (which I couldn't) I found another bug which crashes the package explorer when using a certificate from the certstore because since https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/commit/c1b049a0a29833fa28285a4b86ed2562b209dc5e the `SignPackageViewModel` gets disposed twice.

https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/blob/49d31c58d584ce0773182eff917ab557dd1bea0c/PackageExplorer/MefServices/UIServices.cs#L243

https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/blob/49d31c58d584ce0773182eff917ab557dd1bea0c/PackageViewModel/Commands/SavePackageCommand.cs#L227

Which resulted in into this exception and crashes the application:
![image](https://user-images.githubusercontent.com/4009570/81717734-36d46980-947b-11ea-9160-b590d5b1355f.png)