### PR TITLE
Add check for MemberReference handles when reading assembly attributes

### DIFF
--- a/Core/AssemblyMetadata/AssemblyMetadataParser.cs
+++ b/Core/AssemblyMetadata/AssemblyMetadataParser.cs
@@ -79,7 +79,8 @@ namespace NuGetPe.AssemblyMetadata
             foreach (var attributeHandle in _metadataReader.CustomAttributes)
             {
                 var customAttribute = _metadataReader.GetCustomAttribute(attributeHandle);
-                if (customAttribute.Parent.Kind != HandleKind.AssemblyDefinition)
+                if (customAttribute.Constructor.Kind != HandleKind.MemberReference ||
+                    customAttribute.Parent.Kind != HandleKind.AssemblyDefinition)
                 {
                     continue;
                 }


### PR DESCRIPTION
this avoids InvalidCastExceptions and thus reads more custom attributes

We are only interested in `MemberReference`s and this line throwed the `InvalidCastException` if it is not:
https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/blob/143e66ee5c0414514a7328e2fe4457738c772019/Core/AssemblyMetadata/AssemblyMetadataParser.cs#L87

Checking for the type is not possible because it uses an implicit cast.

---

I got this handled `InvalidCastException` during debugging when opening the `Newtonsoft.Json` package from the nuget.org feed.
It seems that only the `net20` dll is causing the issue.

Before (less metadata is read):
![image](https://user-images.githubusercontent.com/4009570/82650466-03cc6b80-9c1b-11ea-9705-4b0a2dfbf9d8.png)

After (more metadata is read):
![image](https://user-images.githubusercontent.com/4009570/82650501-0929b600-9c1b-11ea-91fc-be38bd2cb06e.png)
