### PR TITLE
SourceLink should be considered valid even if some docs are untracked…

### DIFF
--- a/Core/AssemblyMetadata/AssemblyDebugData.cs
+++ b/Core/AssemblyMetadata/AssemblyDebugData.cs
@@ -30,7 +30,9 @@ namespace NuGetPe.AssemblyMetadata
 
         public bool PdbChecksumIsValid { get; internal set; }
 
-        public bool HasSourceLink => Sources.All(doc => doc.HasSourceLink);
+        public bool HasSourceLink => Sources.Any(doc => doc.HasSourceLink);
+
+        public bool AllSourceLink => Sources.All(doc => doc.HasSourceLink);
 
         public bool HasDebugInfo { get; internal set; }
 
@@ -45,7 +47,9 @@ namespace NuGetPe.AssemblyMetadata
 
             var docs = (from doc in Sources
                         let path = doc.Name.Replace('\\', '/')
-                        where path.Contains("/obj/", StringComparison.OrdinalIgnoreCase) && !doc.IsEmbedded
+                        where (path.Contains("/obj/", StringComparison.OrdinalIgnoreCase) ||
+                               path.Contains("/temp/", StringComparison.OrdinalIgnoreCase) ||
+                               path.Contains("/tmp/", StringComparison.OrdinalIgnoreCase) ) && !doc.IsEmbedded
                         select doc.Name).ToList();
 
             return docs;

--- a/PackageViewModel/SymbolValidation/SymbolValidator.cs
+++ b/PackageViewModel/SymbolValidation/SymbolValidator.cs
@@ -233,7 +233,7 @@ namespace PackageExplorerViewModel
                             }
 
                             // Check for non-embedded sources
-                            if (assemblyMetadata.DebugData.UntrackedSources.Count > 0)
+                            if (assemblyMetadata.DebugData.UntrackedSources.Count > 0 || !assemblyMetadata.DebugData.AllSourceLink)
                             {
                                 var filePair = new FileWithDebugData(file.Primary, assemblyMetadata.DebugData);
                                 untrackedSources.Add(filePair);
@@ -363,7 +363,7 @@ namespace PackageExplorerViewModel
                     sb.AppendLine("To Fix:");
                     sb.AppendLine("<EmbedUntrackedSources>true</EmbedUntrackedSources>");
                     sb.AppendLine("");
-                    sb.AppendLine("Also, workaround in: https://github.com/dotnet/sourcelink/issues/572");
+                    sb.AppendLine("Also, use 3.1.300 SDK to build or\nworkaround in: https://github.com/dotnet/sourcelink/issues/572");
 
                     foreach(var untracked in untrackedSources)
                     {
@@ -543,7 +543,7 @@ namespace PackageExplorerViewModel
                     }
 
                     // Check for non-embedded sources
-                    if(input.DebugData.UntrackedSources.Count > 0)
+                    if(input.DebugData.UntrackedSources.Count > 0 || !input.DebugData.AllSourceLink)
                     {
                         untrackedSources.Add(input);
                     }


### PR DESCRIPTION
…. Untracked sources have a different warning.