### PR TITLE
Use Shift+Enter keyboard shortcut to Open in Shell

### DIFF
--- a/PackageExplorer/MainWindow.xaml
+++ b/PackageExplorer/MainWindow.xaml
@@ -60,6 +60,7 @@
         <KeyBinding Key="F2" Command="{Binding RenameContentCommand}" />
         <KeyBinding Key="Delete" Command="{Binding DeleteContentCommand}" />
         <KeyBinding Key="Enter" Command="{Binding ViewContentCommand}" />
+        <KeyBinding Modifiers="Shift" Key="Enter" Command="{Binding OpenContentFileCommand}" />
     </Window.InputBindings>
 
     <DockPanel x:Name="RootLayout" LastChildFill="True" Visibility="{Binding IsInEditFileMode, Mode=OneWay, FallbackValue=Visible, Converter={StaticResource invertedBoolToVis}}">
@@ -172,7 +173,7 @@
 
             <MenuItem Header="_Content" Margin="3,0" Visibility="{Binding Converter={StaticResource NullToVisibilityConverter}}">
                 <MenuItem Header="View File _Content" Command="{Binding ViewContentCommand}" InputGestureText="Enter" />
-                <MenuItem Header="Open File in Window_s shell..." Command="{Binding OpenContentFileCommand}" />
+                <MenuItem Header="Open File in Window_s shell..." Command="{Binding OpenContentFileCommand}" InputGestureText="Shift+Enter" />
                 <Separator />
                 <MenuItem Header="_Add">
                     <MenuItem.Icon>

--- a/PackageExplorer/PackageViewer.xaml
+++ b/PackageExplorer/PackageViewer.xaml
@@ -364,7 +364,7 @@
 
             <ContextMenu x:Key="SharedContextMenu" DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
                 <MenuItem Header="_View Content" InputGestureText="Enter" Command="{Binding ViewCommand}" CommandParameter="{Binding}" FontWeight="SemiBold" />
-                <MenuItem Header="_Open in Windows shell..." Command="{Binding OpenCommand}" CommandParameter="{Binding}" />
+                <MenuItem Header="_Open in Windows shell..." InputGestureText="Shift+Enter"  Command="{Binding OpenCommand}" CommandParameter="{Binding}" />
                 <MenuItem Header="Open _with..." Command="{Binding OpenWithCommand}" CommandParameter="{Binding}" />
                 <MenuItem Header="_Save As..." Command="{Binding SaveCommand}" CommandParameter="{Binding}" Icon="{StaticResource SaveAsIcon}" />
                 <MenuItem Header="Copy" Command="Copy" Icon="{StaticResource CopyIcon}" />


### PR DESCRIPTION
Add Shift+Enter keyboard shortcut to Open files in Shell.
I use this command frequently to view .dlls in ILSpy and keyboard shortcut will improve my workflow.

* In context menu
  * ![in context menu](https://user-images.githubusercontent.com/1673956/83110789-78b6ff80-a078-11ea-9526-40f6730e4ac2.png)
* In main menu
  * ![in main menu](https://user-images.githubusercontent.com/1673956/83110817-810f3a80-a078-11ea-9c49-4f74df76d38f.png)


The keyboard shortcut is in line with 7zip's
![7zip shortcut](https://user-images.githubusercontent.com/1673956/83110721-5f15b800-a078-11ea-9774-912939d55a9f.png)
