### PR TITLE
Show error message in Package Details Actions

### DIFF
--- a/PackageExplorer/PackageChooser/PackageDetailActionsControl.xaml
+++ b/PackageExplorer/PackageChooser/PackageDetailActionsControl.xaml
@@ -118,5 +118,19 @@
             <Control Margin="7,0,7,0" Template="{StaticResource loadingAnimation}" />
             <Button Content="Cancel" Padding="5,0,5,0" Command="{Binding CancelCommand}" />
         </StackPanel>
+
+        <!-- Error Message -->
+        <TextBlock 
+            Grid.Row="1" 
+            Margin="-10,0,0,0"
+            Padding="5"
+            Background="Beige"
+            MaxHeight="40"
+            Visibility="{Binding ErrorMessage, Converter={StaticResource NullToVisibilityConverter}, Mode=OneWay}"
+            Text="{Binding ErrorMessage}" 
+            Foreground="Black" 
+            VerticalAlignment="Center" 
+            TextWrapping="Wrap"
+            TextTrimming="CharacterEllipsis"/>
     </Grid>
 </UserControl>


### PR DESCRIPTION
see https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/issues/1002

code copied from here:
https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/blob/47c2fc6fd4084fde2fa16d9be5a36fa007936b53/PackageExplorer/PackageChooser/PackageChooserDialog.xaml#L163-L176

Example:
![image](https://user-images.githubusercontent.com/4009570/83276173-84b5d500-a1d0-11ea-95c5-be16cf53363b.png)
