### PR TITLE
Fix read sources from settings in none windows store versions

### DIFF
--- a/PackageExplorer/MefServices/SettingsManager.cs
+++ b/PackageExplorer/MefServices/SettingsManager.cs
@@ -46,7 +46,7 @@ namespace PackageExplorer
                         value = Settings.Default[name];
                         if (typeof(T) == typeof(List<string>) && value is StringCollection sc)
                         {
-                            value = sc.Cast<string>().ToArray();
+                            value = sc.Cast<string>().ToList();
                         }
                     }
 
@@ -64,7 +64,7 @@ namespace PackageExplorer
                     value = Settings.Default[name];
                     if (typeof(T) == typeof(List<string>) && value is StringCollection sc)
                     {
-                        value = sc.Cast<string>().ToArray();
+                        value = sc.Cast<string>().ToList();
                     }
 
                     if (value is T t)


### PR DESCRIPTION
They need to be a `List<string>` instead of `string[]` to pass the `is T` check.