### PR TITLE
Fix blank combobox after adding new feed and prevent double loads

### DIFF
--- a/PackageViewModel/PackageChooser/PackageChooserViewModel.cs
+++ b/PackageViewModel/PackageChooser/PackageChooserViewModel.cs
@@ -377,17 +377,9 @@ namespace PackageExplorerViewModel
 
                     // add the new source to MRU list, after the load succeeds, in case there's an error with the source
                     _packageSourceManager!.NotifyPackageSourceAdded(source);
-                }
-                catch (Exception e)
-                {
-                    _uIServices.Show(e.Message, MessageLevel.Error);
-                }
-            }
-            else
-            {
-                try
-                {
-                    await LoadPackages();
+
+                    // this is to make sure the combo box doesn't goes blank after adding sources
+                    PackageSource = source;
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
After adding a new feed the combobox was blank before:
![image](https://user-images.githubusercontent.com/4009570/83940211-277ade80-a7e3-11ea-88cc-6a79742220de.png)

This is similar to the `PublishPackageViewModel`:
https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/blob/af2a83069e86990d4cf35eb67b6f92600148e1da/PackageViewModel/PublishPackage/PublishPackageViewModel.cs#L275-L284

Also in my testing adding a new feed did load it twice initially but only when it got added when the default feed  wasn't currently selected.
E.g.
- Default feed is selected
- Add new feed "a" -> loaded once because the current feed was the default feed
- Add new feed "b" -> loaded twice because the current feed was "a" and not the default feed