### PR TITLE
Update to latest NuGet

### DIFF
--- a/PackageViewModel/PackageViewModel.csproj
+++ b/PackageViewModel/PackageViewModel.csproj
@@ -10,12 +10,12 @@
   
   <ItemGroup>
     <PackageReference Include="AuthenticodeExaminer" Version="0.3.0" />
-    <PackageReference Include="NuGet.Credentials" Version="$(NuGetDependencyVersion)" />
-    <PackageReference Include="NuGet.PackageManagement" Version="$(NuGetDependencyVersion)" />
+    <PackageReference Include="NuGet.Credentials" Version="5.7.0-xprivate.60022" />
+    <PackageReference Include="NuGet.PackageManagement" Version="5.7.0-xprivate.60022" />
     <!-- Needs 2.1.2 explicitly until https://github.com/NuGet/Home/issues/5957 is fixed -->
     <PackageReference Include="Microsoft.Web.Xdt" Version="2.1.2" /> 
-    <PackageReference Include="NuGet.Commands" Version="$(NuGetDependencyVersion)" />
-    <PackageReference Include="NuGet.Resolver" Version="$(NuGetDependencyVersion)" />
+    <PackageReference Include="NuGet.Commands" Version="5.7.0-xprivate.60022" />
+    <PackageReference Include="NuGet.Resolver" Version="5.7.0-xprivate.60022" />
     <PackageReference Include="System.Windows.Extensions" Version="5.0.0-preview.4.20251.6" />
     <ProjectReference Include="..\Core\Core.csproj" />
   </ItemGroup>

--- a/Types/Types.csproj
+++ b/Types/Types.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <!--<PackageReference Include="Microsoft.Web.Xdt" Version="3.0.0" />-->
-    <PackageReference Include="NuGet.Packaging" Version="$(NuGetDependencyVersion)" />
+    <PackageReference Include="NuGet.Packaging" Version="5.7.0-xprivate.60022" />
     <PackageReference Include="System.ComponentModel.Composition" Version="5.0.0-preview.4.20251.6" />
   </ItemGroup>
 


### PR DESCRIPTION
@campersau Looks like NuGet put an obsolete attribute on `RawSearchResourceV3`:

```
Severity	Code	Description	Project	File	Line	Suppression State
Warning	CS0618	'RawSearchResourceV3' is obsolete: 'Use PackageSearchResource instead (via SourceRepository.GetResourceAsync<PackageSearchResource>'	PackageViewModel	D:\dev\NuGetPackageExplorer\PackageViewModel\PackageChooser\ShowLatestVersionQueryContext.cs	22	Active
```

I see we already have fallback code to use `PackageSearchResource`, do you remember why we use the `RawSearchResourceV3` first?