### PR TITLE
Update to latest

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -40,7 +40,7 @@
     <TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
     <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
     
-    <NuGetDependencyVersion>5.7.0-xprivate.60021</NuGetDependencyVersion>
+    <NuGetDependencyVersion>5.7.0-xprivate.60022</NuGetDependencyVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
@campersau Looks like NuGet put an obsolete attribute on `RawSearchResourceV3`:

```
Severity	Code	Description	Project	File	Line	Suppression State
Warning	CS0618	'RawSearchResourceV3' is obsolete: 'Use PackageSearchResource instead (via SourceRepository.GetResourceAsync<PackageSearchResource>'	PackageViewModel	D:\dev\NuGetPackageExplorer\PackageViewModel\PackageChooser\ShowLatestVersionQueryContext.cs	22	Active
```

I see we already have fallback code to use `PackageSearchResource`, do you remember why we use the `RawSearchResourceV3` first?