### PR TITLE
Switch to official NuGet packages

### DIFF
--- a/Core/Packages/SignatureInfo.cs
+++ b/Core/Packages/SignatureInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Security.Cryptography.Pkcs;
 using NuGet.Packaging.Signing;
 
@@ -13,11 +14,20 @@ namespace NuGetPe
         public SignatureInfo(Signature signature)
         {
             _signature = signature ?? throw new ArgumentNullException(nameof(signature));
+
+            try
+            {
 #pragma warning disable CA1826 // Do not use Enumerable methods on indexable collections. Instead use the collection directly
-            var ts = signature.Timestamps.FirstOrDefault();
+                var ts = signature.Timestamps.FirstOrDefault();
 #pragma warning restore CA1826 // Do not use Enumerable methods on indexable collections. Instead use the collection directly
-            Timestamp = ts?.GeneralizedTime;
-            TimestampSignerInfo = ts?.SignerInfo;
+                Timestamp = ts?.GeneralizedTime;
+                TimestampSignerInfo = ts?.SignerInfo;
+            }
+            catch(CryptographicException) // possibly a malformed timestamp
+            {
+
+            }
+
         }
 
         public SignerInfo SignerInfo => _signature.SignerInfo;

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -40,7 +40,7 @@
     <TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
     <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
     
-    <NuGetDependencyVersion>5.7.0-xprivate.60022</NuGetDependencyVersion>
+    <NuGetDependencyVersion>5.7.0-rtm.6670</NuGetDependencyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>    
-    <add key="BuildPackages" value="https://pkgs.dev.azure.com/dotnet/NuGetPackageExplorer/_packaging/BuildPackages/nuget/v3/index.json"  />
+    <add key="NuGet CI packages" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json"  />
     <add key="Symreader Converter" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"  />
     <add key=".NET Core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json"  />
   </packageSources>


### PR DESCRIPTION
Now that they support x-plat support for code signing, we don't need to use our private version