### PR TITLE
Don't try to open .so and .dylib files as text

### DIFF
--- a/PackageExplorer/MefServices/NativeLibraryFileViewer.cs
+++ b/PackageExplorer/MefServices/NativeLibraryFileViewer.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using System.Windows.Controls;
+using NuGetPackageExplorer.Types;
+
+namespace PackageExplorer
+{
+    [PackageContentViewerMetadata(100, ".so", ".dylib")]
+    internal class NativeLibraryFileViewer : IPackageContentViewer
+    {
+        public object GetView(IPackageContent selectedFile, IReadOnlyList<IPackageContent> peerFiles)
+        {
+            return new Grid();
+        }
+    }
+}

--- a/PackageViewModel/Utilities/FileHelper.cs
+++ b/PackageViewModel/Utilities/FileHelper.cs
@@ -26,7 +26,8 @@ namespace PackageExplorerViewModel
                                                                     ".DLL", ".EXE", ".WINMD", ".CHM", ".PDF",
                                                                     ".DOCX", ".DOC", ".JPG", ".PNG", ".GIF",
                                                                     ".RTF", ".PDB", ".ZIP", ".RAR", ".XAP",
-                                                                    ".VSIX", ".NUPKG", ".SNUPKG", ".SNK", ".PFX", ".ICO"
+                                                                    ".VSIX", ".NUPKG", ".SNUPKG", ".SNK", ".PFX", ".ICO",
+                                                                    ".SO", ".DYLIB"
                                                                 };
 
         public static bool IsBinaryFile(string path)


### PR DESCRIPTION
NuGet packages can contain native libraries for Linux (.so) and macOS (.dylib). This PR treats these extensions an binary files.

I also added an empty viewer for these files, to avoid displaying the `*** The format of this file is not supported. ***` message that would have been shown otherwise. This is only for consistency with what happens when you try to display a native Windows .dll file. You can discard the second commit if you prefer to have the message, but then I guess it would be better to also display something for native Windows .dll files as well.
