### PR TITLE
Fix for #1039

### DIFF
--- a/PackageExplorer/ChocolateyInstall.ps1
+++ b/PackageExplorer/ChocolateyInstall.ps1
@@ -1,7 +1,21 @@
 
-    $drop = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-    $exe = "$drop\NugetPackageExplorer.exe"
+    $drop = Join-Path (Split-Path -parent $MyInvocation.MyCommand.Definition) "tools"
+    $exeName = "NugetPackageExplorer.exe"
+    $exe = Join-Path $drop $exeName
+    
+    New-Item "$exe.gui" -Type File -Force | Out-Null
+
     Install-ChocolateyDesktopLink $exe
+
+    # Generate ignore files for all exe files except "NugetPackageExplorer.exe".
+    # This prevents chocolatey from generating shims for them.
+    $exeFiles = Get-ChildItem $installDir -Include *.exe -Recurse -Exclude $exeName
+
+    foreach ($exeFile in $exeFiles) {
+        # generate an ignore file
+        New-Item "$exeFile.ignore" -Type File -Force | Out-Null
+    }    
+
     $allTypes = (cmd /c assoc)
     $testType1 = $allTypes | ? { $_.StartsWith('.nupkg') }
     if($testType1 -ne $null) {

--- a/PackageExplorer/NugetPackageExplorer.nuspec
+++ b/PackageExplorer/NugetPackageExplorer.nuspec
@@ -21,8 +21,7 @@
   </metadata>
   <files>
     <file src="ChocolateyInstall.ps1"  />
-    <file src="NuGetPackageExplorer.exe.gui"  />
-    <file src="bin\Release\net5.0\win-x64\publish\**\*.*" target=""  />
+    <file src="bin\Release\net5.0\win-x64\publish\**\*.*" target="tools"  />
     <file src="..\LICENSE.txt" target="legal\LICENSE.txt" />
     <file src="..\Build\Verification.txt" target="legal\Verification.txt" />
   </files>


### PR DESCRIPTION
This PR fixes #1039 by moving all files inside the chocolatey package to the "tools" folder and generating gui and ignore files during installation.