### PR TITLE
Fixing wrong path in chocolateyinstall.ps1 introduced by myself...

### DIFF
--- a/PackageExplorer/ChocolateyInstall.ps1
+++ b/PackageExplorer/ChocolateyInstall.ps1
@@ -9,7 +9,7 @@
 
     # Generate ignore files for all exe files except "NugetPackageExplorer.exe".
     # This prevents chocolatey from generating shims for them.
-    $exeFiles = Get-ChildItem $installDir -Include *.exe -Recurse -Exclude $exeName
+    $exeFiles = Get-ChildItem $drop -Include *.exe -Recurse -Exclude $exeName
 
     foreach ($exeFile in $exeFiles) {
         # generate an ignore file


### PR DESCRIPTION
I got the install directory wrong. I don't know why i used the wrong one during my PR and why i didn't notice that.
This PR fixes the errors that now appear during installation of the chocolatey package.