### PR TITLE
catch exceptions when loading images from zip

### DIFF
--- a/PackageExplorer/Converters/PackageIconConverter.cs
+++ b/PackageExplorer/Converters/PackageIconConverter.cs
@@ -28,12 +28,18 @@ namespace PackageExplorer
                     {
                         if (string.Equals(file.Path, iconPath, StringComparison.OrdinalIgnoreCase))
                         {
-                            var image = new BitmapImage();
-                            image.BeginInit();
-                            image.CacheOption = BitmapCacheOption.OnLoad;
-                            image.StreamSource = file.GetStream();
-                            image.EndInit();                            
-                            return image;
+                            // catch potential exceptions during image loading from zip file
+                            // see 1097
+                            try
+                            {
+                                var image = new BitmapImage();
+                                image.BeginInit();
+                                image.CacheOption = BitmapCacheOption.OnLoad;
+                                image.StreamSource = file.GetStream();
+                                image.EndInit();
+                                return image;
+                            }
+                            catch { }
                         }
                     }
 


### PR DESCRIPTION
I couldn't reproduce it during debugging, only when running without debugging and very rarely.
So I just added a try catch to prevent the crash...

fixes https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/issues/1097