### PR TITLE
Fix analysis messages

### DIFF
--- a/PackageViewModel/PackageAnalyzer/MisnamedNativeBuildFileRule.cs
+++ b/PackageViewModel/PackageAnalyzer/MisnamedNativeBuildFileRule.cs
@@ -45,8 +45,8 @@ namespace PackageExplorerViewModel.Rules
             return new PackageIssue(
                 PackageIssueLevel.Warning,
                 "Native build file misnamed",
-                $"The build file '{filename}' does not match the nuget package name. For native packages, this will cause incorrect behavior when being referenced.",
-                $"Rename the build file '{filename}' to match the Nuget package name '{packageName}'."
+                $"The build file '{filename}' does not match the NuGet package name. For native packages, this will cause incorrect behavior when being referenced.",
+                $"Rename the build file '{filename}' to match the NuGet package name '{packageName}'."
             );
         }
     }

--- a/PackageViewModel/PackageAnalyzer/MisplacedAssemblyRule.cs
+++ b/PackageViewModel/PackageAnalyzer/MisplacedAssemblyRule.cs
@@ -53,7 +53,7 @@ namespace PackageExplorerViewModel.Rules
                 PackageIssueLevel.Warning,
                 "Assembly not inside a framework folder",
                 "The assembly '" + target +
-                $"' is placed directly under '{folder}' folder. It is recommended that assemblies be placed inside a framework-specific folder.",
+                $"' is placed directly under the '{folder}' folder. It is recommended that assemblies be placed inside a framework-specific folder.",
                 "Move it into a framework-specific folder. If this assembly is targeted for multiple frameworks, ignore this warning."
                 );
         }
@@ -64,7 +64,7 @@ namespace PackageExplorerViewModel.Rules
                 PackageIssueLevel.Warning,
                 "Assembly outside known folders",
                 "The assembly '" + target +
-                $"' is not inside the '{folder}' folder and hence it won't be used when the package is installed into a project",
+                $"' is inside the '{folder}' folder and hence it won't be used when the package is installed into a project.",
                 "Move it into a known folder."
                 );
         }


### PR DESCRIPTION
I noticed a message in `MisplacedAssemblyRule` which said the reverse of what was intended.
I also took a look at other package analyzer messages while I was at it.