### PR TITLE
Update Ookii.Dialogs.Wpf to v3.0.1 (.NET 5 support)

### DIFF
--- a/PackageExplorer/AboutWindow.xaml
+++ b/PackageExplorer/AboutWindow.xaml
@@ -51,7 +51,7 @@
 				<Run Text="Text editor powered by " /><Hyperlink NavigateUri="https://github.com/icsharpcode/SharpDevelop/wiki/AvalonEdit" Click="Hyperlink_Click"><Run Text="AvalonEdit control" /></Hyperlink><Run Text="." />
             </TextBlock>
             <TextBlock Margin="0,5,0,0">
-				<Run Text="Some dialogs are provided by " /><Hyperlink NavigateUri="http://www.ookii.org/software/dialogs/" Click="Hyperlink_Click"><Run Text="Ookii.Dialogs" /></Hyperlink><Run Text="." />
+				<Run Text="Some dialogs are provided by " /><Hyperlink NavigateUri="https://github.com/augustoproiete/ookii-dialogs-wpf" Click="Hyperlink_Click"><Run Text="Ookii.Dialogs" /></Hyperlink><Run Text="." />
             </TextBlock>
             <TextBlock Margin="0,5,0,0">
 				<Run Text="Some dates are formatted by " /><Hyperlink NavigateUri="https://github.com/Humanizr/Humanizer" Click="Hyperlink_Click"><Run Text="Humanizer" /></Hyperlink><Run Text="." />

--- a/PackageExplorer/NuGetPackageExplorer.csproj
+++ b/PackageExplorer/NuGetPackageExplorer.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="AvalonEdit" Version="6.0.1" />
     <PackageReference Include="GrayscaleEffect" Version="1.0.1" />
     <PackageReference Include="Humanizer" Version="2.8.26" />
-    <PackageReference Include="Ookii.Dialogs.Wpf" Version="1.2.0" />
+    <PackageReference Include="Ookii.Dialogs.Wpf" Version="3.0.1" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
     <PackageReference Include="System.Runtime.Caching" Version="5.0.0" />


### PR DESCRIPTION
- Ookii.Dialogs.Wpf v3.0 adds support for .NET Core 5 (multi-targets `net5.0-windows`, `netcoreapp3.1`, `net45`)
- Ookii.Dialogs.Wpf v2.0 adds support for .NET Core 3.1 (multi-targets `netcoreapp3.1`, `net45`)

https://github.com/augustoproiete/ookii-dialogs-wpf/releases
