### PR TITLE
dotnet-validate: Add initial support for glob patterns in local package validation...

### DIFF
--- a/dotnet-validate/Program.cs
+++ b/dotnet-validate/Program.cs
@@ -68,17 +68,20 @@ namespace NuGetPe
             if (!files.HasMatches)
                 return EXIT_FAILURE;
 
+            using var cancellationTokenSource = new CancellationTokenSource();
+            Console.CancelKeyPress += (_, eventArgs) =>
+            {
+                eventArgs.Cancel = !cancellationTokenSource.IsCancellationRequested;
+                cancellationTokenSource.Cancel();
+            };
+
             foreach (var actualFile in files.Files)
             {
+                cancellationTokenSource.Token
+                    .ThrowIfCancellationRequested();
+
                 try
                 {
-                    using var cancellationTokenSource = new CancellationTokenSource();
-                    Console.CancelKeyPress += (_, eventArgs) =>
-                    {
-                        eventArgs.Cancel = !cancellationTokenSource.IsCancellationRequested;
-                        cancellationTokenSource.Cancel();
-                    };
-
                     var packageFile = new FileInfo(actualFile.Path);
                     if (packageFile.Exists)
                     {

--- a/dotnet-validate/dotnet-validate.csproj
+++ b/dotnet-validate/dotnet-validate.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="5.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
   </ItemGroup>
 


### PR DESCRIPTION
... with the help of Microsoft.Extensions.FileSystemGlobbing. Can handle fully qualified and relative paths, but there might be edge cases.