### PR TITLE
Add a --verbose option to the dotnet-validate package command

### DIFF
--- a/dotnet-validate/PackageDownloader.cs
+++ b/dotnet-validate/PackageDownloader.cs
@@ -18,9 +18,9 @@ namespace NuGetPe
         private readonly ISettings _settings;
         private readonly SourceCacheContext _sourceCacheContext;
 
-        public NuGetPackageDownloader(TextWriter logTextWriter)
+        public NuGetPackageDownloader(ILogger logger)
         {
-            _logger = new TextWriterLogger(logTextWriter);
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _settings = Settings.LoadDefaultSettings(".");
             _sourceCacheContext = new SourceCacheContext();
         }

--- a/dotnet-validate/TextWriterLogger.cs
+++ b/dotnet-validate/TextWriterLogger.cs
@@ -30,7 +30,7 @@ namespace NuGetPe
         private static string FormatMessage(ILogMessage message)
         {
             if (message == null) throw new ArgumentNullException(nameof(message));
-            return $@"[{message.Time:T} {message.Level}] {message.Message}";
+            return $@"<NuGet> [{message.Level}] {message.Message}";
         }
     }
 }


### PR DESCRIPTION
Currently this enables the NuGet package download and installation logs