### PR TITLE
Fix the bytes to hex conversion in checksum header

### DIFF
--- a/Core/AssemblyMetadata/AssemblyDebugParser.cs
+++ b/Core/AssemblyMetadata/AssemblyDebugParser.cs
@@ -331,7 +331,7 @@ namespace NuGetPe.AssemblyMetadata
 
                 var data = peReader.ReadPdbChecksumDebugDirectoryData(entry);
                 var algorithm = data.AlgorithmName;
-                var checksum = data.Checksum.Select(b => b.ToString("x2", CultureInfo.InvariantCulture));
+                var checksum = string.Concat(data.Checksum.Select(b => b.ToString("x2", CultureInfo.InvariantCulture)));
 
                 checksums.Add($"{algorithm}:{checksum}");
             }


### PR DESCRIPTION
Before:
<pre>
GET https://msdl.microsoft.com/download/symbols/microsoft.extensions.logging.pdb/c1cb8bbcf7a4494db76a4035ed47bf08FFFFFFFF/microsoft.extensions.logging.pdb HTTP/1.1
Host: msdl.microsoft.com
<b>SymbolChecksum: SHA256:System.Linq.Enumerable+SelectArrayIterator`2[System.Byte,System.String]</b>
</pre>

After:

<pre>
GET https://msdl.microsoft.com/download/symbols/microsoft.extensions.logging.pdb/c1cb8bbcf7a4494db76a4035ed47bf08FFFFFFFF/microsoft.extensions.logging.pdb HTTP/1.1
Host: msdl.microsoft.com
<b>SymbolChecksum: SHA256:bc8bcbc1a4f74dd9776a4035ed47bf085368921e35560f78487ef3973c823748</b>
</pre>

Doesn't seem to change the behavior but it looked unintentional.