### PR TITLE
Allow existing HttpClient instance to be provided to SymbolValidator

### DIFF
--- a/Core/SymbolValidation/SymbolValidator.cs
+++ b/Core/SymbolValidation/SymbolValidator.cs
@@ -24,12 +24,21 @@ namespace NuGetPe
         private readonly HttpClient _httpClient = new();
 
         public SymbolValidator(IPackage package, string packagePath, IFolder? rootFolder = null)
+            : this(package, packagePath, rootFolder, httpClient: null)
+        {
+        }
+
+        public SymbolValidator(IPackage package, string packagePath, IFolder? rootFolder = null, HttpClient? httpClient = null)
         {
             _package = package ?? throw new ArgumentNullException(nameof(package));
             _packagePath = packagePath ?? throw new ArgumentNullException(nameof(packagePath));
             _rootFolder = rootFolder ?? PathToTreeConverter.Convert(package.GetFiles().ToList());
+            _httpClient = httpClient ?? new();
 
-            UserAgent.SetUserAgent(_httpClient);
+            if (httpClient == null)
+            {
+                UserAgent.SetUserAgent(_httpClient);
+            }
         }
 
         public async Task<SymbolValidatorResult> Validate(CancellationToken cancellationToken = default)

--- a/Core/SymbolValidation/SymbolValidator.cs
+++ b/Core/SymbolValidation/SymbolValidator.cs
@@ -21,7 +21,7 @@ namespace NuGetPe
         private readonly IPackage _package;
         private readonly string _packagePath;
         private readonly IFolder _rootFolder;
-        private readonly HttpClient _httpClient = new();
+        private readonly HttpClient _httpClient;
 
         public SymbolValidator(IPackage package, string packagePath, IFolder? rootFolder = null)
             : this(package, packagePath, rootFolder, httpClient: null)


### PR DESCRIPTION
This facilitates connection pooling or using HttpClientFactory. I attempted to make it completely backward compatible.