### PR TITLE
Use GetRandomFileName when a specific extension is needed

### DIFF
--- a/Core/Utility/TemporaryFile.cs
+++ b/Core/Utility/TemporaryFile.cs
@@ -12,10 +12,12 @@ namespace NuGetPe
 
             if (string.IsNullOrWhiteSpace(extension) || extension[0] != '.')
             {
-                extension = string.Empty;
+                FileName = Path.GetTempFileName();
             }
-
-            FileName = Path.GetTempFileName() + extension;
+            else
+            {
+                FileName = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + extension);
+            }
 
             using var fstream = File.Open(FileName, FileMode.Create);
             stream.CopyTo(fstream);


### PR DESCRIPTION
GetTempFileName actually creates an empty file immediately resulting in empty files left over even when `TemporaryFile` is disposed.

This is perceivable when a .snupkg is downloaded. So if `Path.GetTempFileName()` returns `%TMP%\tmpB067.tmp`, an empty file appears on disk at `%TMP%\tmpB067.tmp` but the `TemporaryFile` code writes to `%TMP%\tmpB067.tmp.snupkg`. When `TemporaryFile` is disposed `%TMP%\tmpB067.tmp.snupkg` is deleted but not `%TMP%\tmpB067.tmp`.