### PR TITLE
make zip package file streams seekable

### DIFF
--- a/Core/Packages/ZipPackageFile.cs
+++ b/Core/Packages/ZipPackageFile.cs
@@ -15,7 +15,7 @@ namespace NuGetPe
         {
             Debug.Assert(reader != null, "reader should not be null");
             LastWriteTime = entry.LastWriteTime;
-            _streamFactory = () => reader.GetStream(UnescapePath(entry.FullName));
+            _streamFactory = () => StreamUtility.MakeSeekable(reader.GetStream(UnescapePath(entry.FullName)), disposeOriginal: true);
         }
 
         // code copied from https://github.com/NuGet/NuGet.Client/blob/91023394890b1458ec0c5940128da73e04089869/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs#L36-L45

--- a/PackageViewModel/Utilities/PackageHelper.cs
+++ b/PackageViewModel/Utilities/PackageHelper.cs
@@ -18,39 +18,6 @@ namespace PackageExplorerViewModel
             // set metadata
             CopyMetadata(packageMetadata, builder);
 
-            // workaround for https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/issues/869
-            string? tempIconFile = null;
-            if (!string.IsNullOrEmpty(packageMetadata.Icon))
-            {
-                var newFiles = new List<IPackageFile>();
-
-                // Normalize any directories to match what's the package
-                // We do this here instead of the metadata so that we round-trip
-                // whatever the user originally had when in edit view
-                var iconPath = packageMetadata.Icon.Replace('/', '\\');
-                foreach (var file in files)
-                {
-                    if (string.Equals(file.Path, iconPath, StringComparison.OrdinalIgnoreCase))
-                    {
-                        tempIconFile = Path.GetTempFileName();
-
-                        using (var stream = file.GetStream())
-                        using (var fileStream = File.OpenWrite(tempIconFile))
-                        {
-                            stream.CopyTo(fileStream);
-                        }
-
-                        newFiles.Add(new DiskPackageFile(file.Path, tempIconFile));
-                    }
-                    else
-                    {
-                        newFiles.Add(file);
-                    }
-                }
-
-                files = newFiles;
-            }
-
             // add files
             builder.Files.AddRange(files);
 
@@ -73,11 +40,6 @@ namespace PackageExplorerViewModel
             {
                 try
                 {
-                    if (tempIconFile != null)
-                    {
-                        File.Delete(tempIconFile);
-                    }
-
                     if (useTempFile && File.Exists(fileNameToUse))
                     {
                         File.Delete(fileNameToUse);


### PR DESCRIPTION
It might be a bit of an overkill to make all zip streams seekable. An alternativ would be to create a `Stream` wrapper which only copies to a `MemoryStream` when `Length` or `Position` gets accessed and the inner `Stream` is not seekable.

fixes #1282