### PR TITLE
fix: Adjust instrumentation key variable

### DIFF
--- a/Uno/NuGetPackageExplorer.Wasm/NuGetPackageExplorer.Wasm.csproj
+++ b/Uno/NuGetPackageExplorer.Wasm/NuGetPackageExplorer.Wasm.csproj
@@ -15,6 +15,8 @@
   </PropertyGroup>
   <ItemGroup>
     <WasmShellMonoEnvironment Include="MSDL_PROXY_LOCATION" Value="$(MsdlApiBaseLocation)" />
+
+    <!-- This value must be the instrumentation key, not the connection string -->
     <WasmShellMonoEnvironment Include="NPE_AI_INSTRUMENTATIONKEY" Value="$(NpeAiInstrumentationKey)" />
   </ItemGroup>
   <ItemGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -174,7 +174,7 @@ stages:
       displayName: Build Uno Apps
       inputs:
         solution: $(build.sourcesdirectory)/NuGetPackageExplorer-uno.slnf
-        msbuildArguments: /r /p:Configuration=Release /p:UNO_BUILD_ONLY=true /p:NpeAiInstrumentationKey=$(AppInsightsKey) /bl:$(Build.ArtifactStagingDirectory)\Logs\$(ReleaseChannel).binlog
+        msbuildArguments: /r /p:Configuration=Release /p:UNO_BUILD_ONLY=true /p:NpeAiInstrumentationKey=$(AppInsightsKeyWebAssembly) /bl:$(Build.ArtifactStagingDirectory)\Logs\$(ReleaseChannel).binlog
         maximumCpuCount: true
       condition: and(succeeded(), or(eq(variables['ReleaseChannel'], 'Nightly'), eq(variables['ReleaseChannel'], 'WebAssembly'), eq(variables['ReleaseChannel'], 'UnoSkia')))
 


### PR DESCRIPTION
Adjust the NPE_AI_INSTRUMENTATIONKEY variable to match what's needed by the javascript version of AppInsights.

@clairernovotny We can do this, or make a different variable that uses the required formatting. Which one do you prefer ?