### PR TITLE
Remove PublishReadyToRunUseCrossgen2 = false workaround

### DIFF
--- a/PackageExplorer/Properties/PublishProfiles/WinARM64.pubxml
+++ b/PackageExplorer/Properties/PublishProfiles/WinARM64.pubxml
@@ -12,7 +12,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun>True</PublishReadyToRun>
-    <PublishReadyToRunUseCrossgen2>false</PublishReadyToRunUseCrossgen2> <!-- Disabled until https://github.com/dotnet/runtime/issues/53770 is fixed -->    
     <PublishTrimmed>False</PublishTrimmed>
   </PropertyGroup>
 </Project>

--- a/PackageExplorer/Properties/PublishProfiles/WinX64.pubxml
+++ b/PackageExplorer/Properties/PublishProfiles/WinX64.pubxml
@@ -12,7 +12,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun>True</PublishReadyToRun>
-    <PublishReadyToRunUseCrossgen2>false</PublishReadyToRunUseCrossgen2> <!-- Disabled until https://github.com/dotnet/runtime/issues/53770 is fixed -->    
     <PublishTrimmed>False</PublishTrimmed>
   </PropertyGroup>
 </Project>

--- a/PackageExplorer/Properties/PublishProfiles/WinX86.pubxml
+++ b/PackageExplorer/Properties/PublishProfiles/WinX86.pubxml
@@ -12,7 +12,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun>True</PublishReadyToRun>
-    <PublishReadyToRunUseCrossgen2>false</PublishReadyToRunUseCrossgen2> <!-- Disabled until https://github.com/dotnet/runtime/issues/53770 is fixed -->    
     <PublishTrimmed>False</PublishTrimmed>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
as the underlying issue has been fixed: https://github.com/dotnet/runtime/issues/53520

I verified it locally with the latest dotnet `6.0.100-preview.6.21355.2`, the build also uses [this version](https://dev.azure.com/dotnet/NuGetPackageExplorer/_build/results?buildId=54529&view=logs&j=2c7fdcf2-b1fe-5e62-1b57-9be1b2fc5893&t=05c8f580-a945-5053-b15b-ca30f2a351d9&l=23).

The `PublishReadyToRunUseCrossgen2` is actually ignored now as it is the only mode see https://github.com/dotnet/core/issues/6325#issuecomment-870119441

Reverts part of https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/pull/1289