### PR TITLE
chore: Update to Uno.Wasm.Bootstrap 3.0.0-dev.129

### DIFF
--- a/Uno/NuGetPackageExplorer.Wasm/NuGetPackageExplorer.Wasm.csproj
+++ b/Uno/NuGetPackageExplorer.Wasm/NuGetPackageExplorer.Wasm.csproj
@@ -59,8 +59,8 @@
     <PackageReference Include="Uno.Monaco.Editor" Version="1.0.2-uno.10" />
     <PackageReference Include="Uno.UI.WebAssembly" Version="3.9.1" />
     <PackageReference Include="Uno.UI.RemoteControl" Version="3.9.1" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.Wasm.Bootstrap" Version="3.0.0-dev.87" />
-    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="3.0.0-dev.87" />
+    <PackageReference Include="Uno.Wasm.Bootstrap" Version="3.0.0-dev.129" />
+    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="3.0.0-dev.129" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.2" />
 		<PackageReference Include="System.ComponentModel.Composition" Version="6.0.0-preview.1.21102.12" />
   </ItemGroup>


### PR DESCRIPTION
Fixes a runtime performance issue, fixes double download for PWA offline worker