### PR TITLE
Fix issues around PE and PDB association

### DIFF
--- a/PackageExplorer/MefServices/PdbFileViewer.cs
+++ b/PackageExplorer/MefServices/PdbFileViewer.cs
@@ -24,10 +24,20 @@ namespace PackageExplorer
         {
             DiagnosticsClient.TrackEvent("PdbFileViewer");
 
-            // Get the PE file, exe or dll that matches
-            var pe = peerFiles.FirstOrDefault(pc => ".dll".Equals(Path.GetExtension(pc.Name), StringComparison.OrdinalIgnoreCase) ||
-                                                     ".exe".Equals(Path.GetExtension(pc.Name), StringComparison.OrdinalIgnoreCase) ||
-                                                     ".winmd".Equals(Path.GetExtension(pc.Name), StringComparison.OrdinalIgnoreCase));
+            IPackageContent? pe = null;
+
+            if (selectedFile.Name.EndsWith(".ni.pdb", StringComparison.OrdinalIgnoreCase))
+            {
+                // This case is to ensure we are prioritize the ni dll (ngen framework case).
+                pe = peerFiles.FirstOrDefault(pc => pc.Name.EndsWith(".ni.dll", StringComparison.OrdinalIgnoreCase));
+            }
+
+            // Cascade to trying the dll/winmd, this is the crossgen/crossgen2 case of .NET Core/.NET 5+
+            pe ??= peerFiles.FirstOrDefault(pc => ".dll".Equals(Path.GetExtension(pc.Name), StringComparison.OrdinalIgnoreCase) ||
+                                                ".winmd".Equals(Path.GetExtension(pc.Name), StringComparison.OrdinalIgnoreCase));
+
+            // Get the exe as a last resort, the stand-alone case (.NET Single file or .NET Framework app)
+            pe ??= peerFiles.FirstOrDefault(pc =>  ".exe".Equals(Path.GetExtension(pc.Name), StringComparison.OrdinalIgnoreCase));
 
 #pragma warning disable CA2000 // Dispose objects before losing scope -- ReadDebugData will dispose
             var peStream = pe != null

--- a/PackageViewModel/PackagePart/PackageFile.cs
+++ b/PackageViewModel/PackagePart/PackageFile.cs
@@ -60,10 +60,29 @@ namespace PackageExplorerViewModel
         /// <returns></returns>
         public IEnumerable<PackageFile> GetAssociatedPackageFiles()
         {
-            var filename = System.IO.Path.GetFileNameWithoutExtension(Name);
+            const string niPdbExt = ".ni.pdb";
 
-            static bool HasSameName(IPart packagePart, string name) =>
-                System.IO.Path.GetFileNameWithoutExtension(packagePart.Name).Equals(name, StringComparison.OrdinalIgnoreCase);
+            string? filename = null;
+
+            if (Name.EndsWith(niPdbExt, StringComparison.OrdinalIgnoreCase))
+            {
+                filename = Name.AsSpan()[..(Name.Length - niPdbExt.Length)].ToString();
+            }
+
+            filename ??= System.IO.Path.GetFileNameWithoutExtension(Name);
+
+            static bool HasSameName(IPart packagePart, string name)
+            {
+                if (System.IO.Path.GetFileNameWithoutExtension(packagePart.Name).Equals(name, StringComparison.OrdinalIgnoreCase))
+                    return true;
+
+                if (packagePart.Name.EndsWith(niPdbExt, StringComparison.OrdinalIgnoreCase))
+                {
+                    var nameNoExt = packagePart.Name.AsSpan()[..(packagePart.Name.Length - niPdbExt.Length)];
+                    return nameNoExt.CompareTo(name, StringComparison.OrdinalIgnoreCase) == 0;
+                }
+                return false;
+            }
 
             return _parent!.GetFiles().OfType<PackageFile>().Where(f => f.Path != Path && HasSameName(f, filename));
         }


### PR DESCRIPTION
Fixes #1392

- Fixes case where a PDB could be associated with the EXE host on a self-contained deployment.
- Fixes NI PDBs getting reported as portable.
- Fixes reporting type of PDB, even if conversion fails (in case matching DLL is not embedded).
