### PR TITLE
fix(uno): Disable close button on inspector tabs

### DIFF
--- a/Uno/NugetPackageExplorer.Legacy/Views/Styles/Controls/TabViewItem.xaml
+++ b/Uno/NugetPackageExplorer.Legacy/Views/Styles/Controls/TabViewItem.xaml
@@ -9,6 +9,7 @@
         <Setter Property="HorizontalContentAlignment" Value="Left"/>
         <Setter Property="FontSize" Value="18"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="IsClosable" Value="False"/>
         <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
         <Setter Property="Template">
             <Setter.Value>


### PR DESCRIPTION
Update to more recent builds of `TabControl` includes a fix for default `TabView.IsClosable`, causing close buttons to appear incorrectly.