### PR TITLE
(#1480) Fix desktop shortcut in Chocolatey

### DIFF
--- a/PackageExplorer/ChocolateyInstall.ps1
+++ b/PackageExplorer/ChocolateyInstall.ps1
@@ -2,10 +2,25 @@
     $drop = Join-Path (Split-Path -parent $MyInvocation.MyCommand.Definition) "tools"
     $exeName = "NugetPackageExplorer.exe"
     $exe = Join-Path $drop $exeName
+
+    $pp = Get-PackageParameters
+
+    if(-not $pp['NoDesktopShortcut']) {
+        $desktop = Join-Path $env:Public -ChildPath 'Desktop'
+        $shortcutFile =  Join-Path $desktop -ChildPath "$($exeName.Split('.')[0]).lnk"
+        
+        $shortcutArgs = @{
+            ShortcutFilePath = $shortcutFile
+            TargetPath = $exe
+            WorkingDirectory = $drop
+            Desciption = 'NuGet Package Explorer'
+        }
+
+        Install-ChocolateyShortcut @shortcutArgs
+
+    }
     
     New-Item "$exe.gui" -Type File -Force | Out-Null
-
-    Install-ChocolateyDesktopLink $exe
 
     # Generate ignore files for all exe files except "NugetPackageExplorer.exe".
     # This prevents chocolatey from generating shims for them.

--- a/PackageExplorer/NugetPackageExplorer.nuspec
+++ b/PackageExplorer/NugetPackageExplorer.nuspec
@@ -14,6 +14,12 @@
       NuGet Package Explorer is an application which allows creating and exploring NuGet packages easily.
       After installing it, you can double click on a .nupkg or .snupkg file to view the package content.
       You can also load packages directly from the official NuGet feed.
+
+      ### Available Package Parameters
+
+      - `/NoDesktopShortut` : Don't create a desktop shortcut when installing
+
+      Example: `choco install nugetpackageexplorer -y --params="'/NoDesktopShortcut'"`
     </description>
     <summary>Makes creating and examining nuget packages very easy.</summary>
     <releaseNotes>https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/releases</releaseNotes>


### PR DESCRIPTION
Prior to version 1.0.0 of Chocolatey the Install-DesktopLink helper function
could be used to create shortcuts. This function has been deprecated and now
removed from Chocolatey as of version 1.0.0

This commit refactors the chocolateyInstall.ps1 script to use the supported
Install-ChocolateyShortcut function to provide the functionality.

Additionally, package parameters have been introduced to allow folks installing
from the chocolatey package to opt-out of having a desktop icon created for them.

This additional functionality, including usage, has been documented in the nuspec
file description, so that it is available for people looking at the package on the
Chocolatey Community Repository.

Fixes #1480 