### PR TITLE
Use long for DownloadCount

### DIFF
--- a/Core/Packages/PackageInfo.cs
+++ b/Core/Packages/PackageInfo.cs
@@ -58,7 +58,7 @@ namespace NuGetPe
         /// <summary>
         /// Gets or sets the number of package downloads.
         /// </summary>
-        public int? DownloadCount { get; set; }
+        public long? DownloadCount { get; set; }
 
         /// <summary>
         /// Gets or sets the time of the packages publishing.

--- a/Core/Packages/SimplePackage.cs
+++ b/Core/Packages/SimplePackage.cs
@@ -125,7 +125,7 @@ namespace NuGetPe
             get { return null; }
         }
 
-        public int DownloadCount
+        public long DownloadCount
         {
             get { return -1; }
         }

--- a/Core/Packages/ZipPackage.cs
+++ b/Core/Packages/ZipPackage.cs
@@ -243,7 +243,7 @@ namespace NuGetPe
             get { return null; }
         }
 
-        public int DownloadCount
+        public long DownloadCount
         {
             get { return -1; }
         }

--- a/PackageExplorer/Converters/NumberToStringConverter.cs
+++ b/PackageExplorer/Converters/NumberToStringConverter.cs
@@ -13,6 +13,10 @@ namespace PackageExplorer
             {
                 return i.ToMetric(decimals: 1);
             }
+            if (value is long l)
+            {
+                return ((double)l).ToMetric(decimals: 1);
+            }
             if (value is double dbl)
             {
                 return dbl.ToMetric(decimals: 1);

--- a/PackageViewModel/EmptyPackage.cs
+++ b/PackageViewModel/EmptyPackage.cs
@@ -119,7 +119,7 @@ namespace PackageExplorerViewModel
             get { return null; }
         }
 
-        public int DownloadCount
+        public long DownloadCount
         {
             get { return -1; }
         }

--- a/PackageViewModel/PackageChooser/PackageInfoViewModel.cs
+++ b/PackageViewModel/PackageChooser/PackageInfoViewModel.cs
@@ -347,7 +347,7 @@ namespace PackageExplorerViewModel
 
             var versionInfo = versionInfos?.FirstOrDefault(v => v.Version == packageSearchMetadata.Identity.Version);
 
-            var downloadCount = (int?)(versionInfo?.DownloadCount ?? packageSearchMetadata.DownloadCount);
+            var downloadCount = versionInfo?.DownloadCount ?? packageSearchMetadata.DownloadCount;
 
             return new PackageInfo(packageSearchMetadata.Identity)
             {

--- a/Types/Packages/IServerPackageMetadata.cs
+++ b/Types/Packages/IServerPackageMetadata.cs
@@ -5,6 +5,6 @@ namespace NuGetPe
     public interface IServerPackageMetadata
     {
         Uri? ReportAbuseUrl { get; }
-        int DownloadCount { get; }
+        long DownloadCount { get; }
     }
 }


### PR DESCRIPTION
NuGet.Client changed it in 2015 https://github.com/NuGet/NuGet.Client/commit/79dc5ffb6876bd9474999bab5260d272d1c39e2a
But I didn't change it here when I was refactoring the code to use NuGet.Client https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/pull/326/files#diff-9c77df4f6fc32ba617a357e20f394c3179aeaf759b909411f87cf22bdce59839R291

![image](https://user-images.githubusercontent.com/4009570/184286448-51827b40-f106-426b-8d47-00f84649677e.png)

https://nuget.info is not affected:
https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/blob/2a7060e07d2ba5c5ebaa06ebf80048987d5de161/Uno/NugetPackageExplorer.Legacy/Client/Data/PackageData.cs#L22

Fixes #1522