### PR TITLE
fix: Adjust Uno source generation after 17.3 update

### DIFF
--- a/Uno/NuGetPackageExplorer.Skia.Gtk/NuGetPackageExplorer.Skia.Gtk.csproj
+++ b/Uno/NuGetPackageExplorer.Skia.Gtk/NuGetPackageExplorer.Skia.Gtk.csproj
@@ -6,7 +6,6 @@
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>PackageExplorer</AssemblyName>
     <RootNamespace>PackageExplorer</RootNamespace>
-    <UnoUIUseRoslynSourceGenerators>false</UnoUIUseRoslynSourceGenerators>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup Condition="exists('..\NuGetPackageExplorer.UWP')">

--- a/Uno/NuGetPackageExplorer.Wasm/NuGetPackageExplorer.Wasm.csproj
+++ b/Uno/NuGetPackageExplorer.Wasm/NuGetPackageExplorer.Wasm.csproj
@@ -6,7 +6,6 @@
     <NoWarn>NU1701</NoWarn>
     <AssemblyName>PackageExplorer</AssemblyName>
     <RootNamespace>PackageExplorer</RootNamespace>
-    <UnoUIUseRoslynSourceGenerators>false</UnoUIUseRoslynSourceGenerators>
     <WasmShellWebAppBasePath>/</WasmShellWebAppBasePath>
     <WasmPWAManifestFile>manifest.json</WasmPWAManifestFile>
     <MsdlApiBaseLocation>api/MsdlProxy</MsdlApiBaseLocation>

--- a/Uno/NuGetPackageExplorer.macOS/NuGetPackageExplorer.macOS.csproj
+++ b/Uno/NuGetPackageExplorer.macOS/NuGetPackageExplorer.macOS.csproj
@@ -12,6 +12,9 @@
     <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
     <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
     <IsPackable>false</IsPackable>
+
+    <!-- force the use of Roslyn hosted generators https://github.com/unoplatform/uno/discussions/9531 -->
+    <UnoUIUseRoslynSourceGenerators>true</UnoUIUseRoslynSourceGenerators>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
See https://github.com/unoplatform/uno/discussions/9531 for details. The use of `Uno.SourceGenerationTasks` is not needed for this projects, and generation can happen directly in Roslyn.