### PR TITLE
fix(wasm): Allow for packages with metadata in the version to be downloaded properly

### DIFF
--- a/PackageExplorer/MefServices/PackageDownloader.cs
+++ b/PackageExplorer/MefServices/PackageDownloader.cs
@@ -83,7 +83,7 @@ namespace PackageExplorer
 #if __WASM__
             // FIXME#14: we are bypassing the entire implementation, because DownloadResource could not be created on WASM (but works skia)
             return NugetEndpoint
-                .DownloadPackage(packageIdentity.Id, packageIdentity.Version.OriginalVersion)
+                .DownloadPackage(packageIdentity.Id, packageIdentity.Version.ToNormalizedString())
                 .ContinueWith(x =>
                 {
                     var path = $"./tmp/{Guid.NewGuid()}.nupkg";


### PR DESCRIPTION
Fixes the ability for packages to be downloaded in the wasm version, when version contains metadata (1.2.5+sha123abdef).