### PR TITLE
Remove unused `args` argument

### DIFF
--- a/Uno/NuGetPackageExplorer.Skia.Gtk/Program.cs
+++ b/Uno/NuGetPackageExplorer.Skia.Gtk/Program.cs
@@ -17,7 +17,7 @@ namespace PackageExplorer
 				expArgs.ExitApplication = true;
 			};
 
-			var host = new GtkHost(() => new App(), args);
+			var host = new GtkHost(() => new App());
 
 			host.Run();
 		}


### PR DESCRIPTION
https://github.com/unoplatform/uno/blob/45c85c08ca4e52dbc62fb11feb19b26996e15bbb/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs#L67-L79

The constructor that takes `args` will be removed in Uno 5 and `args` is already unused.