### PR TITLE
Support more NuGet feeds for symbol validation than just nuget.org.

### DIFF
--- a/PackageViewModel/Commands/SavePackageCommand.cs
+++ b/PackageViewModel/Commands/SavePackageCommand.cs
@@ -214,7 +214,7 @@ namespace PackageExplorerViewModel
                 }
                 catch (Exception ex)
                 {
-                    DiagnosticsClient.TrackException(ex, ViewModel.Package, ViewModel.PublishedOnNuGetOrg);
+                    DiagnosticsClient.TrackException(ex, ViewModel.Package, ViewModel.PublishedOnline);
                     ViewModel.UIServices.Show(ex.Message, MessageLevel.Error);
                 }
             }
@@ -273,7 +273,7 @@ namespace PackageExplorerViewModel
                     }
                     catch (Exception ex)
                     {
-                        DiagnosticsClient.TrackException(ex, ViewModel.Package, ViewModel.PublishedOnNuGetOrg);
+                        DiagnosticsClient.TrackException(ex, ViewModel.Package, ViewModel.PublishedOnline);
                         ViewModel.UIServices.Show(ex.Message, MessageLevel.Error);
                     }
                 }

--- a/PackageViewModel/Commands/ViewContentCommand.cs
+++ b/PackageViewModel/Commands/ViewContentCommand.cs
@@ -62,7 +62,7 @@ namespace PackageExplorerViewModel
                     {
                         if (!(e is IOException))
                         {
-                            DiagnosticsClient.TrackException(e, ViewModel.Package, ViewModel.PublishedOnNuGetOrg);
+                            DiagnosticsClient.TrackException(e, ViewModel.Package, ViewModel.PublishedOnline);
                         }
 
                         ViewModel.UIServices.Show(e.Message, MessageLevel.Error);
@@ -106,7 +106,7 @@ namespace PackageExplorerViewModel
                 }
                 catch (Exception ex) when (!(ex is FileNotFoundException))
                 {
-                    DiagnosticsClient.TrackException(ex, ViewModel.Package, ViewModel.PublishedOnNuGetOrg);
+                    DiagnosticsClient.TrackException(ex, ViewModel.Package, ViewModel.PublishedOnline);
                     // don't let plugin crash the app
                     content = Resources.PluginFailToReadContent + Environment.NewLine + ex.ToString();
                 }

--- a/PackageViewModel/PackageViewModel.cs
+++ b/PackageViewModel/PackageViewModel.cs
@@ -93,8 +93,8 @@ namespace PackageExplorerViewModel
 
 
             RootFolder = PathToTreeConverter.Convert(Package.GetFiles().ToList(), this);
-            PackagePath = path; // also sets symbol validator
             PackageSource = source;
+            PackagePath = path; // also sets symbol validator
 
             _packageMetadata = new EditablePackageMetadata(Package, UIServices, this);
 
@@ -181,7 +181,7 @@ namespace PackageExplorerViewModel
             }
         }
 
-        public bool PublishedOnNuGetOrg => SymbolValidator!.IsPublicPackage;
+        public bool PublishedOnline => SymbolValidator!.IsPublicPackage;
 
         public IPackage Package { get; }
 
@@ -274,7 +274,7 @@ namespace PackageExplorerViewModel
                 {
                     _packagePath = value;
 
-                    SymbolValidator = new SymbolValidator(Package, PackagePath, RootFolder);
+                    SymbolValidator = new SymbolValidator(Package, PackagePath, PackageSource, RootFolder);
                     OnPropertyChanged(nameof(PackageSource));
                     OnPropertyChanged(nameof(SymbolValidator));
 
@@ -948,7 +948,7 @@ namespace PackageExplorerViewModel
                 {
                     if (!(ex is IOException) && !(ex is ArgumentException) && !(ex is UnauthorizedAccessException))
                     {
-                        DiagnosticsClient.TrackException(ex, Package, PublishedOnNuGetOrg);
+                        DiagnosticsClient.TrackException(ex, Package, PublishedOnline);
                     }
                     UIServices.Show(ex.Message, MessageLevel.Error);
                 }
@@ -988,7 +988,7 @@ namespace PackageExplorerViewModel
             }
             catch (Exception ex)
             {
-                DiagnosticsClient.TrackException(ex, Package, PublishedOnNuGetOrg);
+                DiagnosticsClient.TrackException(ex, Package, PublishedOnline);
                 UIServices.Show("The command failed with this error message:" +
                                 Environment.NewLine +
                                 Environment.NewLine +
@@ -1405,7 +1405,7 @@ namespace PackageExplorerViewModel
             {
                 if (!(e is ArgumentException))
                 {
-                    DiagnosticsClient.TrackException(e, Package, PublishedOnNuGetOrg);
+                    DiagnosticsClient.TrackException(e, Package, PublishedOnline);
                 }
                 UIServices.Show(e.Message, MessageLevel.Error);
             }

--- a/PackageViewModel/PackageViewModelFactory.cs
+++ b/PackageViewModel/PackageViewModelFactory.cs
@@ -78,7 +78,7 @@ namespace PackageExplorerViewModel
                 ContentViewerMetadata,
                 PackageRules);
 
-            DiagnosticsClient.TrackEvent("PackageViewModelFactory_CreateViewModel", package, pvm.PublishedOnNuGetOrg);
+            DiagnosticsClient.TrackEvent("PackageViewModelFactory_CreateViewModel", package, pvm.PublishedOnline);
 
             return pvm;
         }

--- a/dotnet-validate/Program.cs
+++ b/dotnet-validate/Program.cs
@@ -180,7 +180,7 @@ namespace NuGetPe
         {
             using var package = new ZipPackage(packageFile.FullName);
 
-            var validator = new SymbolValidator(package, packageFile.FullName);
+            var validator = new SymbolValidator(package, packageFile.FullName, packageFile.FullName);
             var result = await validator.Validate(cancellationToken).ConfigureAwait(false);
             await WriteResult("Source Link", result.SourceLinkResult, result.SourceLinkErrorMessage, SourceLinkDescription).ConfigureAwait(false);
             await WriteResult("Deterministic (dll/exe)", result.DeterministicResult, result.DeterministicErrorMessage, DeterministicDescription).ConfigureAwait(false);


### PR DESCRIPTION
Feeds can differ in how the package ID and version has to be formatted.
This implementation supports nuget.org and myget.org (and possibly others).

Fixes #1626