### PR TITLE
Fix displaying multiple AssemblyMetadata attribute values

### DIFF
--- a/Core/AssemblyMetadata/AssemblyMetaDataInfo.cs
+++ b/Core/AssemblyMetadata/AssemblyMetaDataInfo.cs
@@ -10,8 +10,8 @@ namespace NuGetPe.AssemblyMetadata
     /// </summary>
     public class AssemblyMetaDataInfo
     {
-        private readonly Dictionary<string, string> _metadataEntries = new Dictionary<string, string>();
-        public IReadOnlyDictionary<string, string> MetadataEntries => _metadataEntries;
+        private readonly List<KeyValuePair<string, string>> _metadataEntries = new List<KeyValuePair<string, string>>();
+        public IReadOnlyList<KeyValuePair<string, string>> MetadataEntries => _metadataEntries;
         public string FullName { get; internal set; }
         public string StrongName { get; internal set; }
         public IEnumerable<AssemblyName> ReferencedAssemblies { get; private set; } = Enumerable.Empty<AssemblyName>();
@@ -70,7 +70,7 @@ namespace NuGetPe.AssemblyMetadata
                 throw new ArgumentNullException(nameof(displayName));
             }
 
-            _metadataEntries[displayName] = value;
+            _metadataEntries.Add(new KeyValuePair<string, string>(displayName, value));
         }
     }
 }


### PR DESCRIPTION
We were using a Dictionary to store the assembly metadata with the attribute name as the key, but an assembly can have multiple instances of an attribute e.g. the `AssemblyMetadataAttribute` so we were overwriting the previous values.

**Before:**

<img width="563" alt="image" src="https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/assets/1376924/db557b0d-4762-4e84-9f2e-cd8fb5107291">

<p></p>


**After:**

<img width="542" alt="image" src="https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/assets/1376924/c9fa3a79-60d2-4f64-b351-eb0b4fad68b1">


