### PR TITLE
Use a descriptive file extension for temporary files

### DIFF
--- a/Core/SymbolValidation/SymbolValidator.cs
+++ b/Core/SymbolValidation/SymbolValidator.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -199,7 +199,12 @@ namespace NuGetPe
                     {
 
                         using var str = file.Primary.GetStream();
-                        using var tempFile = new TemporaryFile(str);
+
+                        // Use descriptive file extension so files that appear in file system logging or that are
+                        // leftover during an abrupt process termination can be debugged easier
+                        var tempFileExtension = ".npe" + (string.IsNullOrEmpty(file.Primary.Extension) ? ".dat" : file.Primary.Extension);
+
+                        using var tempFile = new TemporaryFile(str, tempFileExtension);
 
                         var assemblyMetadata = AssemblyMetadataReader.ReadMetaData(tempFile.FileName);
 
@@ -285,7 +290,7 @@ namespace NuGetPe
 #else
                             using var getStream = await response.Content!.ReadAsStreamAsync().ConfigureAwait(false);
 #endif
-                            using var tempFile = new TemporaryFile(getStream, ".snupkg");
+                            using var tempFile = new TemporaryFile(getStream, ".npe.snupkg");
                             await ReadSnupkgFile(tempFile.FileName).ConfigureAwait(false);
                         }
                     }


### PR DESCRIPTION
We use NuGetPackageExplorer.Core package in [NuGet Insights](https://github.com/NuGet/insights). We have some file system logging that shows strange activity in the temp folder. The only place we use `Path.GetTempFileName` appears to be in this library. I would like to verify this by making NPE's temp files more identifiable, with a `.npe.dll` or `.npe.snupkg` file extension.