### PR TITLE
Add ITemporaryPathProvider to allow more temp file customization

### DIFF
--- a/Core/SymbolValidation/ITemporaryPathProvider.cs
+++ b/Core/SymbolValidation/ITemporaryPathProvider.cs
@@ -3,15 +3,15 @@
 namespace NuGetPe
 {
     /// <summary>
-    /// Generates temporarily files.
+    /// Generates temporary files.
     /// </summary>
     public interface ITemporaryFileProvider
     {
         /// <summary>
-        /// Provides a <see cref="TemporaryFile"/>, given optional context values.
+        /// Provides a <see cref="TemporaryFile"/>, given a readable stream and optional context values.
         /// </summary>
-        /// <param name="stream">The stream that will be written to the temporary file.</param>
-        /// <param name="package">The package related to the temp file that will be created.</param>
+        /// <param name="stream">The stream that will be written to a temporary file on disk.</param>
+        /// <param name="package">The package related to the temporary file that will be created.</param>
         /// <param name="fileName">The desired file name for the temporary file.</param>
         /// <returns>The temporary file, written to disk.</returns>
         public TemporaryFile GetTemporaryFile(Stream stream, IPackage? package, string? fileName);

--- a/Core/SymbolValidation/ITemporaryPathProvider.cs
+++ b/Core/SymbolValidation/ITemporaryPathProvider.cs
@@ -13,7 +13,8 @@ namespace NuGetPe
         /// <param name="stream">The stream that will be written to a temporary file on disk.</param>
         /// <param name="package">The package related to the temporary file that will be created.</param>
         /// <param name="fileName">The desired file name for the temporary file.</param>
+        /// <param name="part">The part of the package that will be written to the temporary file, for context purposes.</param>
         /// <returns>The temporary file, written to disk.</returns>
-        public TemporaryFile GetTemporaryFile(Stream stream, IPackage? package, string? fileName);
+        public TemporaryFile GetTemporaryFile(Stream stream, IPackage? package, string? fileName, IPart? part);
     }
 }

--- a/Core/SymbolValidation/ITemporaryPathProvider.cs
+++ b/Core/SymbolValidation/ITemporaryPathProvider.cs
@@ -1,0 +1,18 @@
+﻿namespace NuGetPe
+{
+    /// <summary>
+    /// Generates a path for a temporary file. Can be used with <see cref="TemporaryFile"/> to allow more control for
+    /// the naming of temporary files.
+    /// </summary>
+    public interface ITemporaryPathProvider
+    {
+        /// <summary>
+        /// Provides a path, given optional context values. A fully qualified path must be returned. The caller of this
+        /// method should be able to write to the returned path. The directory must exist.
+        /// </summary>
+        /// <param name="package">The package related to the temp file that will be created.</param>
+        /// <param name="fileName">The desired file name for the temporary file.</param>
+        /// <returns>A full path to where the temporary file will be stored.</returns>
+        public string GetPath(IPackage? package, string? fileName);
+    }
+}

--- a/Core/SymbolValidation/ITemporaryPathProvider.cs
+++ b/Core/SymbolValidation/ITemporaryPathProvider.cs
@@ -1,18 +1,19 @@
-﻿namespace NuGetPe
+﻿using System.IO;
+
+namespace NuGetPe
 {
     /// <summary>
-    /// Generates a path for a temporary file. Can be used with <see cref="TemporaryFile"/> to allow more control for
-    /// the naming of temporary files.
+    /// Generates temporarily files.
     /// </summary>
-    public interface ITemporaryPathProvider
+    public interface ITemporaryFileProvider
     {
         /// <summary>
-        /// Provides a path, given optional context values. A fully qualified path must be returned. The caller of this
-        /// method should be able to write to the returned path. The directory must exist.
+        /// Provides a <see cref="TemporaryFile"/>, given optional context values.
         /// </summary>
+        /// <param name="stream">The stream that will be written to the temporary file.</param>
         /// <param name="package">The package related to the temp file that will be created.</param>
         /// <param name="fileName">The desired file name for the temporary file.</param>
-        /// <returns>A full path to where the temporary file will be stored.</returns>
-        public string GetPath(IPackage? package, string? fileName);
+        /// <returns>The temporary file, written to disk.</returns>
+        public TemporaryFile GetTemporaryFile(Stream stream, IPackage? package, string? fileName);
     }
 }

--- a/Core/SymbolValidation/SymbolValidator.cs
+++ b/Core/SymbolValidation/SymbolValidator.cs
@@ -205,13 +205,12 @@ namespace NuGetPe
                     try
                     {
 
-                        using var str = file.Primary.GetStream();
+                        using var stream = file.Primary.GetStream();
 
                         // Use descriptive file extension so files that appear in file system logging or that are
                         // leftover during an abrupt process termination can be debugged easier
                         var tempFileExtension = ".npe" + (string.IsNullOrEmpty(file.Primary.Extension) ? ".dat" : file.Primary.Extension);
-
-                        using var tempFile = GetTemporaryFile(str, tempFileExtension, file.Primary.Name);
+                        using var tempFile = GetTemporaryFile(stream, extension: tempFileExtension, part: file.Primary);
 
                         var assemblyMetadata = AssemblyMetadataReader.ReadMetaData(tempFile.FileName);
 
@@ -298,7 +297,7 @@ namespace NuGetPe
 #else
                             using var getStream = await response.Content!.ReadAsStreamAsync().ConfigureAwait(false);
 #endif
-                            using var tempFile = GetTemporaryFile(getStream, ".npe.snupkg", fileName);
+                            using var tempFile = GetTemporaryFile(getStream, extension: ".npe.snupkg", name: fileName);
                             await ReadSnupkgFile(tempFile.FileName).ConfigureAwait(false);
                         }
                     }
@@ -554,15 +553,15 @@ namespace NuGetPe
                 compilerFlagsResult, compilerFlagsMessage);
         }
 
-        private TemporaryFile GetTemporaryFile(Stream stream, string tempExtension, string fileName)
+        private TemporaryFile GetTemporaryFile(Stream stream, string? extension = null, string? name = null, IPart? part = null)
         {
             if (_tempProvider is not null)
             {
-                return _tempProvider.GetTemporaryFile(stream, _package, fileName);
+                return _tempProvider.GetTemporaryFile(stream, _package, name, part);
             }
             else
             {
-                return new TemporaryFile(stream, tempExtension);
+                return new TemporaryFile(stream, extension);
             }
         }
 

--- a/Core/Utility/TemporaryFile.cs
+++ b/Core/Utility/TemporaryFile.cs
@@ -6,39 +6,30 @@ namespace NuGetPe
     public sealed class TemporaryFile : IDisposable
     {
         public TemporaryFile(Stream stream, string? extension = null)
-            : this(GeneratePath(extension), stream)
         {
-        }
-
-        public TemporaryFile(string path, Stream stream)
-        {
-            if (path == null)
-                throw new ArgumentNullException(nameof(path));
             if (stream == null)
                 throw new ArgumentNullException(nameof(stream));
 
-            var directory = Path.GetDirectoryName(path);
-            if (directory is not null && !Directory.Exists(directory))
+            if (string.IsNullOrWhiteSpace(extension) || extension[0] != '.')
             {
-                Directory.CreateDirectory(directory);
+                FileName = Path.GetTempFileName();
+            }
+            else
+            {
+                FileName = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + extension);
             }
 
-            FileName = path;
             using var fstream = File.Open(FileName, FileMode.Create);
             stream.CopyTo(fstream);
             fstream.Flush();
         }
 
-        private static string GeneratePath(string? extension)
+        public TemporaryFile(string path)
         {
-            if (string.IsNullOrWhiteSpace(extension) || extension[0] != '.')
-            {
-                return Path.GetTempFileName();
-            }
-            else
-            {
-                return Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + extension);
-            }
+            if (path == null)
+                throw new ArgumentNullException(nameof(path));
+
+            FileName = path;
         }
 
         public string FileName { get; }


### PR DESCRIPTION
My project (NuGet Insights) is getting alerts for some temp files generated by SymbolValidator. I can tell because ".npe" is seen in the file extension, per https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/pull/1670. I would like a way of fully customizing the temporary files so I can enhance my logging, select specific temporary directory, etc.