### PR TITLE
ci: Adjust cors function publication for CPM

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -178,7 +178,8 @@ stages:
       artifact: SigningScripts
 
     - powershell: |
-        dotnet clean Uno\NuGetPackageExplorer\NuGetPackageExplorer.WinUI.csproj
+        cd Uno
+        git clean -fdx
       displayName: Clean Uno tree
       condition: and(succeeded(), or(eq(variables['ReleaseChannel'], 'Nightly'), eq(variables['ReleaseChannel'], 'WebAssembly')))
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -148,7 +148,7 @@ stages:
 
     - powershell: |
         dotnet publish Uno\NuGetPackageExplorer\NuGetPackageExplorer.WinUI.csproj -f net9.0-browserwasm /p:NpeAiInstrumentationKey=$(AppInsightsKeyWebAssembly) /bl:$(Build.ArtifactStagingDirectory)\Logs\$(ReleaseChannel).binlog
-      displayName: Build Uno Desktop App
+      displayName: Build Uno Wasm App
       condition: and(succeeded(), or(eq(variables['ReleaseChannel'], 'Nightly'), eq(variables['ReleaseChannel'], 'WebAssembly')))
 
     - task: CopyFiles@2
@@ -160,11 +160,6 @@ stages:
         CleanTargetFolder: false
         OverWrite: false
         flattenFolders: false
-      condition: and(succeeded(), eq(variables['ReleaseChannel'], 'WebAssembly'))
-
-    - publish: '$(build.sourcesdirectory)/Uno'
-      displayName: Publish Cors bypass Azure Function
-      artifact: CorsAzureFunction
       condition: and(succeeded(), eq(variables['ReleaseChannel'], 'WebAssembly'))
 
     - publish: $(Build.ArtifactStagingDirectory)\$(ReleaseChannel)
@@ -181,6 +176,16 @@ stages:
     - publish: Build
       displayName: Publish signing scripts
       artifact: SigningScripts
+
+    - powershell: |
+        dotnet clean Uno\NuGetPackageExplorer\NuGetPackageExplorer.WinUI.csproj
+      displayName: Clean Uno tree
+      condition: and(succeeded(), or(eq(variables['ReleaseChannel'], 'Nightly'), eq(variables['ReleaseChannel'], 'WebAssembly')))
+
+    - publish: '$(build.sourcesdirectory)/Uno'
+      displayName: Publish Cors bypass Azure Function
+      artifact: CorsAzureFunction
+      condition: and(succeeded(), eq(variables['ReleaseChannel'], 'WebAssembly'))
 
 - stage: CodeSign
   dependsOn: Build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -162,7 +162,7 @@ stages:
         flattenFolders: false
       condition: and(succeeded(), eq(variables['ReleaseChannel'], 'WebAssembly'))
 
-    - publish: '$(build.sourcesdirectory)/Uno/Api'
+    - publish: '$(build.sourcesdirectory)/Uno'
       displayName: Publish Cors bypass Azure Function
       artifact: CorsAzureFunction
       condition: and(succeeded(), eq(variables['ReleaseChannel'], 'WebAssembly'))


### PR DESCRIPTION
As we're using CPM for the uno app subtree, we need to provide it to the release pipeline entirely for the versions to be picked up properly. A similar change is needed in the release pipeline to use the `Api` folder.