### PR TITLE
Update signing certificate retrieval and package versions

### DIFF
--- a/Core/SymbolValidation/SymbolValidator.cs
+++ b/Core/SymbolValidation/SymbolValidator.cs
@@ -571,7 +571,7 @@ namespace NuGetPe
             var peFile = new PeNet.PeFile(stream);
 
             var subject = AppCompat.IsSupported(RuntimeFeature.Cryptography)
-                ? peFile.Authenticode?.SigningCertificate?.Subject
+                ? peFile.AuthenticodeInfo?.SigningCertificate?.Subject
                 : CryptoUtility.GetSigningCertificate(peFile)?.Subject.ToString();
 
             return subject?.EndsWith(", O=Microsoft Corporation, L=Redmond, S=Washington, C=US", StringComparison.OrdinalIgnoreCase) == true;

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
     <PackageVersion Include="OSVersionHelper" Version="1.1.24" />
-    <PackageVersion Include="PeNet" Version="2.9.7" />
+    <PackageVersion Include="PeNet" Version="4.1.1" />
 
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
@@ -37,12 +37,13 @@
     <PackageVersion Include="System.ComponentModel.Composition" Version="$(SystemDependencyVersion)" />
     
     <PackageVersion Include="System.Formats.Asn1" Version="$(SystemDependencyVersion)" />
-    <PackageVersion Include="System.Memory" Version="4.5.5" />
+    <PackageVersion Include="System.Memory" Version="4.6.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="System.Reflection.Metadata" Version="$(SystemDependencyVersion)" />
-    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
     <PackageVersion Include="System.Runtime.Caching" Version="$(SystemDependencyVersion)" />    
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="$(SystemDependencyVersion)" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="$(SystemDependencyVersion)" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />    
     <PackageVersion Include="System.Windows.Extensions" Version="$(SystemDependencyVersion)" />


### PR DESCRIPTION
Update signing certificate retrieval and package versions

- Upgraded `PeNet` package from version `2.9.7` to `4.1.1`.
- Updated `System.Memory` from `4.5.5` to `4.6.0`.
- Updated `System.Runtime.CompilerServices.Unsafe` from `6.0.0` to `6.1.0`.