### PR TITLE
Improve platform detection and code initialization

### DIFF
--- a/Core/Utility/AppCompat.cs
+++ b/Core/Utility/AppCompat.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
 [assembly: DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
 
@@ -9,13 +7,13 @@ namespace NuGetPe
     public static class AppCompat
     {
 #pragma warning disable IDE1006 // Naming Styles
-        private static readonly Lazy<bool> isWindows10S = new Lazy<bool>(GetIsWin10S);
+        private static readonly Lazy<bool> isWindows10S = new Lazy<bool>(() => IsWindows && GetIsWin10S());
 #pragma warning restore IDE1006 // Naming Styles
 
         public static bool IsWindows10S => isWindows10S.Value;
 
         public static bool IsWasm => RuntimeInformation.OSArchitecture ==
-#if NET5_0
+#if NET5_0_OR_GREATER
             Architecture.Wasm;
 #else
             (Architecture)4; // Architecture.Wasm definition is missing under NETSTANDARD2_1 & NETCOREAPP3_1

--- a/PackageViewModel/Commands/ViewContentCommand.cs
+++ b/PackageViewModel/Commands/ViewContentCommand.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using System.IO;
 using System.Text;
 using System.Windows.Input;
 
@@ -184,9 +181,7 @@ namespace PackageExplorerViewModel
             var extension = Path.GetExtension(file.Name);
 
             return from p in ViewModel.ContentViewerMetadata
-#if !NETSTANDARD2_1
                    where AppCompat.IsWindows10S ? p.Metadata.SupportsWindows10S : true // Filter out incompatible addins on 10s
-#endif
                    where p.Metadata.SupportedExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase)
                    orderby p.Metadata.Priority
                    select p.Value;

--- a/PackageViewModel/PackageViewModel.cs
+++ b/PackageViewModel/PackageViewModel.cs
@@ -281,7 +281,7 @@ namespace PackageExplorerViewModel
                     {
                         if (result!.IsFile && File.Exists(value))
                         {
-#if !NETSTANDARD2_1 // UNO TODO: Use proper platform detection
+#if !HAS_UNO // UNO TODO: Use proper platform detection
                             // Clean up the old one since we can't reliably change the Filter without a race
                             if (_watcher != null)
                             {

--- a/PackageViewModel/PackageViewModelFactory.cs
+++ b/PackageViewModel/PackageViewModelFactory.cs
@@ -60,7 +60,7 @@ namespace PackageExplorerViewModel
             if (package is null || packagePath is null)
                 return null;
 
-#if !NETSTANDARD2_1 // UNO TODO: Use proper platform detection; wasm: System.Security.Cryptography.Encoding is not supported on this platform.
+#if !HAS_UNO // UNO TODO: Use proper platform detection; wasm: System.Security.Cryptography.Encoding is not supported on this platform.
             // If it's a zip package, we need to load the verification data so it's ready for later
             if (package is ISignaturePackage zip)
             {


### PR DESCRIPTION
Improve platform detection and code initialization

- Refactored `isWindows10S` initialization in `AppCompat.cs` to use a lambda expression.
- Updated conditional compilation directives from `NET5_0` to `NET5_0_OR_GREATER` in `AppCompat.cs`.
- Added and removed using directives in `ViewContentCommand.cs`, and included a check for `AppCompat.IsWindows10S` in `FindContentViewer`.
- Changed conditional compilation in `PackageViewModel.cs` and `PackageViewModelFactory.cs` from `NETSTANDARD2_1` to `HAS_UNO` to enhance platform detection.