### PR TITLE
Add versioning enhancements and metadata attributes

### DIFF
--- a/Uno/Directory.Build.targets
+++ b/Uno/Directory.Build.targets
@@ -1,2 +1,21 @@
 ﻿<Project>
+
+    <Target Name="AddCommitHashToAssemblyAttributes" BeforeTargets="GetAssemblyAttributes">
+    <ItemGroup>
+      <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition=" '$(SourceRevisionId)' != '' ">
+        <_Parameter1>CommitHash</_Parameter1>
+        <_Parameter2>$(SourceRevisionId)</_Parameter2>
+      </AssemblyAttribute>
+
+      <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition=" '$(PublicRelease)' == 'true' ">
+        <_Parameter1>CloudBuildNumber</_Parameter1>
+        <_Parameter2>$(BuildVersionSimple)</_Parameter2>
+      </AssemblyAttribute>
+      <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition=" '$(PublicRelease)' == 'false' ">
+        <_Parameter1>CloudBuildNumber</_Parameter1>
+        <_Parameter2>$(BuildVersionSimple)$(SemVerBuildSuffix)</_Parameter2>
+      </AssemblyAttribute>
+    </ItemGroup>
+
+  </Target>
 </Project>

--- a/Uno/Directory.Packages.props
+++ b/Uno/Directory.Packages.props
@@ -5,6 +5,8 @@
     See https://aka.platform.uno/using-uno-sdk for more information.
   -->
   <ItemGroup>
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.7.115"  />
+
     <PackageVersion Include="System.IO.Packaging" Version="9.0.0" />
     <PackageVersion Include="System.Reactive" Version="5.0.0" />
 

--- a/Uno/NuGetPackageExplorer/Assets/version.xml
+++ b/Uno/NuGetPackageExplorer/Assets/version.xml
@@ -1,0 +1,2 @@
+﻿<NuGetPackageExplorer Version="1.0">
+</NuGetPackageExplorer>

--- a/Uno/NuGetPackageExplorer/Assets/version.xml
+++ b/Uno/NuGetPackageExplorer/Assets/version.xml
@@ -1,2 +1,2 @@
-﻿<NuGetPackageExplorer Version="1.0">
-</NuGetPackageExplorer>
+﻿<Application Name="NuGet Package Explorer" Version="1.0">
+</Application>

--- a/Uno/NuGetPackageExplorer/NuGetPackageExplorer.WinUI.csproj
+++ b/Uno/NuGetPackageExplorer/NuGetPackageExplorer.WinUI.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>
-      net9.0-windows10.0.19041;
-      net9.0-desktop;
+    <TargetFrameworks>      
       net9.0-browserwasm;
+      net9.0-windows10.0.19041;
+      net9.0-desktop
     </TargetFrameworks>
 
     <OutputType>Exe</OutputType>

--- a/Uno/NuGetPackageExplorer/NuGetPackageExplorer.WinUI.csproj
+++ b/Uno/NuGetPackageExplorer/NuGetPackageExplorer.WinUI.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>      
-      net9.0-browserwasm;
+    <TargetFrameworks>   
       net9.0-windows10.0.19041;
-      net9.0-desktop
+      net9.0-desktop;
+      net9.0-browserwasm
     </TargetFrameworks>
 
     <OutputType>Exe</OutputType>

--- a/Uno/NuGetPackageExplorer/NuGetPackageExplorer.WinUI.csproj
+++ b/Uno/NuGetPackageExplorer/NuGetPackageExplorer.WinUI.csproj
@@ -18,8 +18,8 @@
     <!-- App Identifier -->
     <ApplicationId>info.nuget.nugetpackageexplorer</ApplicationId>
     <!-- Versions -->
-    <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
-    <ApplicationVersion>1</ApplicationVersion>
+    <ApplicationDisplayVersion>$(BuildVersionSimple)</ApplicationDisplayVersion>
+    <ApplicationVersion>$(BuildVersionSimple)</ApplicationVersion>
 
   </PropertyGroup>
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,7 +71,7 @@ stages:
         $manifest.Save(".\PackageExplorer.Package\Package-Nightly.appxmanifest")
 
         [xml]$versionFile = Get-Content ".\Uno\NuGetPackageExplorer\Assets\version.xml"
-        $versionFile.Version = "$(Build.BuildNumber)"
+        $versionFile.Application.Version = "$(Build.BuildNumber)"
         $versionFile.Save(".\Uno\NuGetPackageExplorer\Assets\version.xml")
 
         # Update badges

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,6 +70,10 @@ stages:
         $manifest.Package.Identity.Version = "$(GitBuildVersionSimple).0"
         $manifest.Save(".\PackageExplorer.Package\Package-Nightly.appxmanifest")
 
+        [xml]$versionFile = Get-Content ".\Uno\NuGetPackageExplorer\Assets\version.xml"
+        $versionFile.Version = "$(Build.BuildNumber)"
+        $versionFile.Save(".\Uno\NuGetPackageExplorer\Assets\version.xml")
+
         # Update badges
         [xml]$badge = Get-Content ".\Build\ci_badge.svg"
         $badge.svg.g[1].text[2].InnerText = "$(GitBuildVersionSimple).0"


### PR DESCRIPTION
- Introduced `AddCommitHashToAssemblyAttributes` target in `Directory.Build.targets` to include commit hash and cloud build number in assembly metadata.
- Added `Nerdbank.GitVersioning` package reference in `Directory.Packages.props` for improved version management, along with specific versions for several dependencies.
- Updated application versioning in `NuGetPackageExplorer.WinUI.csproj` to use `$(BuildVersionSimple)` for dynamic versioning.