### PR TITLE
Update routing and caching for .NET and package files

### DIFF
--- a/Uno/NuGetPackageExplorer/Platforms/WebAssembly/wwwroot/staticwebapp.config.json
+++ b/Uno/NuGetPackageExplorer/Platforms/WebAssembly/wwwroot/staticwebapp.config.json
@@ -18,7 +18,13 @@
       }
     },
     {
-      "route": "/_framework/dotnet.*",
+      "route": "/_framework/dotnet.js",
+      "headers": {
+        "cache-control": "must-revalidate, max-age=3600"
+      }
+    },
+    {
+      "route": "/_framework/dotnet.js.*",
       "headers": {
         "cache-control": "must-revalidate, max-age=3600"
       }
@@ -34,6 +40,10 @@
       "headers": {
         "cache-control": "public, immutable, max-age=31536000"
       }
+    },
+    {
+      "route": "/packages*",
+      "rewrite": "/index.html"
     },
     {
       "route": "/*",

--- a/Uno/NuGetPackageExplorer/Platforms/WebAssembly/wwwroot/staticwebapp.config.json
+++ b/Uno/NuGetPackageExplorer/Platforms/WebAssembly/wwwroot/staticwebapp.config.json
@@ -42,10 +42,6 @@
       }
     },
     {
-      "route": "/packages*",
-      "rewrite": "/index.html"
-    },
-    {
       "route": "/*",
       "headers": {
         "cache-control": "must-revalidate, max-age=3600"


### PR DESCRIPTION
Update routing and caching for .NET and package files

- Update cache-control headers.
- Added a new route for `/packages/*` that rewrites to `/index.html`