### PR TITLE
Add conditional signature verification in ZipPackage.cs

### DIFF
--- a/Core/Packages/ZipPackage.cs
+++ b/Core/Packages/ZipPackage.cs
@@ -354,6 +354,7 @@ namespace NuGetPe
 
         public async Task VerifySignatureAsync()
         {
+#if IS_SIGNING_SUPPORTED
             using var reader = new PackageArchiveReader(_streamFactory(), false);
             var signed = await reader.IsSignedAsync(CancellationToken.None).ConfigureAwait(false);
             if (signed)
@@ -369,6 +370,10 @@ namespace NuGetPe
 
                 VerificationResult = await verifier.VerifySignaturesAsync(reader, SignedPackageVerifierSettings.GetVerifyCommandDefaultPolicy(), CancellationToken.None).ConfigureAwait(false);
             }
+#else
+            VerificationResult = null!;
+            await Task.CompletedTask; // no-op for the warning due to the ifdef
+#endif
         }
 
         private void EnsureManifest()


### PR DESCRIPTION
Add conditional signature verification in ZipPackage.cs

Implement conditional compilation in VerifySignatureAsync to handle package signing based on the IS_SIGNING_SUPPORTED symbol.