### PR TITLE
Update package versions and project properties

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,19 +5,19 @@
 
 
     <NuGetDependencyVersion>6.13.2</NuGetDependencyVersion>
-    <SystemDependencyVersion>9.0.2</SystemDependencyVersion>
+    <SystemDependencyVersion>9.0.3</SystemDependencyVersion>
   </PropertyGroup>
   <ItemGroup>
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.7.115"  />
 
     <PackageVersion Include="AppInsights.WindowsDesktop" Version="2.18.1" />
-    <PackageVersion Include="AuthenticodeExaminer" Version="0.3.0" />
+    <PackageVersion Include="AuthenticodeExaminer" Version="0.4.0" />
     <PackageVersion Include="AvalonEdit" Version="6.3.0.90" />
     <PackageVersion Include="GrayscaleEffect" Version="1.0.1" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
     <PackageVersion Include="OSVersionHelper" Version="1.1.24" />
-    <PackageVersion Include="PeNet" Version="4.1.1" />
+    <PackageVersion Include="PeNet" Version="4.1.2" />
 
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
@@ -40,11 +40,11 @@
     <PackageVersion Include="System.ComponentModel.Composition" Version="$(SystemDependencyVersion)" />
     
     <PackageVersion Include="System.Formats.Asn1" Version="$(SystemDependencyVersion)" />
-    <PackageVersion Include="System.Memory" Version="4.6.0" />
+    <PackageVersion Include="System.Memory" Version="4.6.2" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="System.Reflection.Metadata" Version="$(SystemDependencyVersion)" />
-    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
+    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.1" />
     <PackageVersion Include="System.Runtime.Caching" Version="$(SystemDependencyVersion)" />    
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="$(SystemDependencyVersion)" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="$(SystemDependencyVersion)" />

--- a/Uno/Directory.Packages.props
+++ b/Uno/Directory.Packages.props
@@ -1,4 +1,4 @@
-<Project ToolsVersion="15.0">
+<Project>
   <!--
     To update the version of Uno, you should instead update the Sdk version in the global.json file.
 
@@ -10,9 +10,9 @@
     <PackageVersion Include="System.IO.Packaging" Version="9.0.0" />
     <PackageVersion Include="System.Reactive" Version="5.0.0" />
 
-    <PackageVersion Include="Uno.CommunityToolkit.WinUI.UI.Controls" Version="7.1.200" />
-    <PackageVersion Include="Uno.CommunityToolkit.WinUI.UI.Controls.DataGrid" Version="7.1.200" />
-    <PackageVersion Include="Uno.Core" Version="4.0.1" />
+    <PackageVersion Include="Uno.CommunityToolkit.WinUI.UI.Controls" Version="7.1.204" />
+    <PackageVersion Include="Uno.CommunityToolkit.WinUI.UI.Controls.DataGrid" Version="7.1.204" />
+    <PackageVersion Include="Uno.Core" Version="4.1.1" />
     <PackageVersion Include="Uno.Monaco.Editor" Version="2.0.0-dev.60" />
     
     
@@ -25,8 +25,8 @@
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.2" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.3.2" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.1" />
     <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
-    <PackageVersion Include="Microsoft.Windows.Compatibility" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Windows.Compatibility" Version="9.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Update package versions and project properties

- Bump `SystemDependencyVersion` to `9.0.3`.
- Upgrade `AuthenticodeExaminer` to `0.4.0`.
- Update `PeNet` to `4.1.2`.
- Upgrade `System.Memory` to `4.6.2`.
- Update `System.Runtime.CompilerServices.Unsafe` to `6.1.1`.
- Upgrade `Uno.CommunityToolkit.WinUI.UI.Controls` to `7.1.204`.
- Upgrade `Uno.CommunityToolkit.WinUI.UI.Controls.DataGrid` to `7.1.204`.
- Update `Uno.Core` to `4.1.1`.
- Upgrade `Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore` to `2.0.1`.
- Update `Microsoft.Windows.Compatibility` to `9.0.3`.

Fixes #1633 by way of using the latest AuthenticodeExaminer