### PR TITLE
Add HTTP client service to dependency injection

### DIFF
--- a/Uno/Api/Program.cs
+++ b/Uno/Api/Program.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Azure.Functions.Worker;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -11,6 +10,7 @@ var host = Host.CreateDefaultBuilder()
     {
         s.AddApplicationInsightsTelemetryWorkerService();
         s.ConfigureFunctionsApplicationInsights();
+        s.AddHttpClient();
 
         s.Configure<LoggerFilterOptions>(options =>
         {


### PR DESCRIPTION
Add HTTP client service to dependency injection

This commit introduces the addition of an HTTP client service to the dependency injection container in the Azure Functions application by including `s.AddHttpClient();` in the `ConfigureServices` method. It also removes the unused import statement for `Microsoft.Extensions.Configuration`.