### PR TITLE
Comment out WebAssembly-specific build settings

### DIFF
--- a/Uno/NuGetPackageExplorer/NuGetPackageExplorer.WinUI.csproj
+++ b/Uno/NuGetPackageExplorer/NuGetPackageExplorer.WinUI.csproj
@@ -48,17 +48,17 @@
         <DefineConstants>$(DefineConstants);USE_MONACO_EDITOR</DefineConstants>
 
         <WasmShellEnableIDBFS>true</WasmShellEnableIDBFS>
-        <WasmShellMonoRuntimeExecutionMode>InterpreterAndAOT</WasmShellMonoRuntimeExecutionMode>
+        <!--<WasmShellMonoRuntimeExecutionMode>InterpreterAndAOT</WasmShellMonoRuntimeExecutionMode>-->
         <WasmShellEnableEmccProfiling>true</WasmShellEnableEmccProfiling>
 
         <!-- Disable the jitinterpreter for possible interp crash -->
-        <WasmShellEnableJiterpreter>false</WasmShellEnableJiterpreter>
+        <!--<WasmShellEnableJiterpreter>false</WasmShellEnableJiterpreter>-->
 
         <!--<WasmShellGenerateAOTProfile>true</WasmShellGenerateAOTProfile>-->
       </PropertyGroup>
 
       <ItemGroup>
-        <WasmShellEnableAotProfile Include="$(NpeSrcRoot)\Build\aot.profile" />
+        <!--<WasmShellEnableAotProfile Include="$(NpeSrcRoot)\Build\aot.profile" />-->
         
         <WasmShellMonoEnvironment Include="MSDL_PROXY_LOCATION" Value="$(MsdlApiBaseLocation)" />
 


### PR DESCRIPTION
The `<WasmShellMonoRuntimeExecutionMode>` property was commented out, removing the explicit `InterpreterAndAOT` runtime mode.

The `<WasmShellEnableJiterpreter>` property, previously set to `false`, was also commented out, no longer explicitly disabling the JIT interpreter.

The `<WasmShellEnableAotProfile>` item, which referenced an AOT profile file, was commented out, removing its inclusion in the build process.

These changes simplify or disable certain WebAssembly-related configurations, potentially for debugging or testing purposes.