### PR TITLE
Update Uno.Sdk version in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -6,7 +6,7 @@
 
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "6.4.20",
+    "Uno.Sdk": "6.4.26",
     "Uno.Sdk.Private": "6.5.0-dev.43.gb4dabf8cea"
   }
 }


### PR DESCRIPTION
Update Uno.Sdk version in global.json

Updated the `Uno.Sdk` version in `global.json` from `6.4.20` to `6.4.26` to maintain project dependencies and ensure compatibility with the latest features and fixes. Refer to the provided link in the file for more information on upgrading Uno packages.