### PR TITLE
Update Uno packages and adjust NuGet configuration

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="Uno.CommunityToolkit.WinUI.UI.Controls" Version="$(UnoCommunityToolkitVersion)" />
     <PackageVersion Include="Uno.CommunityToolkit.WinUI.UI.Controls.DataGrid" Version="$(UnoCommunityToolkitVersion)" />
     <PackageVersion Include="Uno.Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.4.2" />
-    <PackageVersion Include="Uno.Monaco.Editor" Version="6.4.0-dev.25.gb8530c2257" />
+    <PackageVersion Include="Uno.Monaco.Editor" Version="6.4.0-dev.41.gfc42320b13" />
     <PackageVersion Include="System.Reactive" Version="5.0.0" />    
     
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0-2.final" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -5,7 +5,7 @@
     <!--<add key="NuGet CI packages" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json"  />-->
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"  />
     <add key="BuildPackages" value="https://pkgs.dev.azure.com/dotnet/NuGetPackageExplorer/_packaging/BuildPackages/nuget/v3/index.json" />
-    <add key="uno-dev" value="https://pkgs.dev.azure.com/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_packaging/unoplatformdev/nuget/v3/index.json" />
+    <!--<add key="uno-dev" value="https://pkgs.dev.azure.com/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_packaging/unoplatformdev/nuget/v3/index.json" />-->
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
@@ -22,14 +22,14 @@
       <package pattern="Microsoft.DiaSymReader.*" />
       <package pattern="NuGet.*" />
     </packageSource>
-    <packageSource key="uno-dev">
+    <!--<packageSource key="uno-dev">
       <package pattern="Uno.*" />
-    </packageSource>
+    </packageSource>-->
     <packageSource key="BuildPackages">
-      <package pattern="Uno.*" />
+      <!--<package pattern="Uno.*" />-->
       <package pattern="NuGetKeyVaultSignTool.Core" />
       <package pattern="NuGetPackageExplorer.*" />
-      <package pattern="Uno.Monaco.Editor" />
+      <!--<package pattern="Uno.Monaco.Editor" />-->
     </packageSource>
   </packageSourceMapping>
   <activePackageSource>

--- a/global.json
+++ b/global.json
@@ -6,7 +6,7 @@
 
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "6.4.31",
+    "Uno.Sdk": "6.4.42",
     "Uno.Sdk.Private": "6.5.0-dev.43.gb4dabf8cea"
   }
 }


### PR DESCRIPTION
Updated the `Uno.Monaco.Editor` package version from `6.4.0-dev.25.gb8530c2257` to `6.4.0-dev.41.gfc42320b13` in `Directory.Packages.props`.

Commented out the `uno-dev` package source in `NuGet.config` to indicate it is no longer actively used.

Upgraded the `Uno.Sdk` version in `global.json` from `6.4.31` to `6.4.42` to align with the latest SDK version.