### PR TITLE
Add feature support to copy package signature info.

### DIFF
--- a/PackageExplorer/Resources.resx
+++ b/PackageExplorer/Resources.resx
@@ -359,15 +359,6 @@ Do you want to add '{0}' to the list of package publish sources?</value>
   <data name="ValidationResult_Copy" xml:space="preserve">
     <value>Copy</value>
   </data>
-  <data name="ValidationResult_Errors" xml:space="preserve">
-    <value>Errors:</value>
-  </data>
-  <data name="ValidationResult_Info" xml:space="preserve">
-    <value>Information:</value>
-  </data>
-  <data name="ValidationResult_Warnings" xml:space="preserve">
-    <value>Warnings:</value>
-  </data>
   <data name="Validation_Disallowed" xml:space="preserve">
     <value>Disallowed</value>
   </data>
@@ -404,10 +395,16 @@ Do you want to add '{0}' to the list of package publish sources?</value>
   <data name="Validation_Unknown" xml:space="preserve">
     <value>Unknown</value>
   </data>
+  <data name="Validation_ValidExternal" xml:space="preserve">
+    <value>Valid with Symbol Server</value>
+  </data>
   <data name="Validation_Valid" xml:space="preserve">
     <value>Valid</value>
   </data>
-  <data name="Validation_ValidExternal" xml:space="preserve">
-    <value>Valid with Symbol Server</value>
+  <data name="Error" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="Copy_Error" xml:space="preserve">
+    <value>Failed to copy validation summary to clipboard.</value>
   </data>
 </root>

--- a/PackageExplorer/Resources.resx
+++ b/PackageExplorer/Resources.resx
@@ -112,10 +112,10 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Dialog_CreatedByLabel" xml:space="preserve">
     <value>Authors:</value>
@@ -355,6 +355,18 @@ Do you want to add '{0}' to the list of package publish sources?</value>
   </data>
   <data name="ProxyConnectToMessage" xml:space="preserve">
     <value>Connect to {0}</value>
+  </data>
+  <data name="ValidationResult_Copy" xml:space="preserve">
+    <value>Copy</value>
+  </data>
+  <data name="ValidationResult_Errors" xml:space="preserve">
+    <value>Errors:</value>
+  </data>
+  <data name="ValidationResult_Info" xml:space="preserve">
+    <value>Information:</value>
+  </data>
+  <data name="ValidationResult_Warnings" xml:space="preserve">
+    <value>Warnings:</value>
   </data>
   <data name="Validation_Disallowed" xml:space="preserve">
     <value>Disallowed</value>

--- a/PackageExplorer/ValidationResultWindow.xaml
+++ b/PackageExplorer/ValidationResultWindow.xaml
@@ -49,7 +49,7 @@
 
         <Border DockPanel.Dock="Bottom" Margin="0,30,0,0" BorderThickness="0,0.5,0,0" BorderBrush="{DynamicResource ResourceKey={x:Static SystemColors.ActiveBorderBrushKey}}" Background="{DynamicResource ResourceKey={x:Static SystemColors.ControlBrushKey}}">
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                <Button Content="Copy" Padding="20,0,20,0" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="10,10,15,10" Click="CopyButton_Click" />
+                <Button Content="{x:Static self:Resources.ValidationResult_Copy}" Padding="20,0,20,0" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="10,10,15,10" Click="CopyButton_Click" />
                 <Button Content="OK" Padding="20,0,20,0" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="10,10,15,10" IsDefault="True" IsCancel="True" Click="Button_Click" />
             </StackPanel>
         </Border>

--- a/PackageExplorer/ValidationResultWindow.xaml
+++ b/PackageExplorer/ValidationResultWindow.xaml
@@ -48,7 +48,10 @@
     <DockPanel LastChildFill="true">
 
         <Border DockPanel.Dock="Bottom" Margin="0,30,0,0" BorderThickness="0,0.5,0,0" BorderBrush="{DynamicResource ResourceKey={x:Static SystemColors.ActiveBorderBrushKey}}" Background="{DynamicResource ResourceKey={x:Static SystemColors.ControlBrushKey}}">
-            <Button Content="OK" Padding="20,0,20,0" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="10,10,15,10" IsDefault="True" IsCancel="True" Click="Button_Click" />
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button Content="Copy" Padding="20,0,20,0" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="10,10,15,10" Click="CopyButton_Click" />
+                <Button Content="OK" Padding="20,0,20,0" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="10,10,15,10" IsDefault="True" IsCancel="True" Click="Button_Click" />
+            </StackPanel>
         </Border>
 
         <StackPanel Orientation="Vertical" DockPanel.Dock="Top" Margin="15,20,15,0">

--- a/PackageExplorer/ValidationResultWindow.xaml.cs
+++ b/PackageExplorer/ValidationResultWindow.xaml.cs
@@ -1,8 +1,11 @@
 ﻿using System.Windows;
+
 using NuGetPe;
-using Clipboard = System.Windows.Forms.Clipboard;
 
 using PackageExplorerViewModel;
+
+using StringResources = PackageExplorer.Resources;
+using Clipboard = System.Windows.Forms.Clipboard;
 
 namespace PackageExplorer
 {
@@ -34,7 +37,7 @@ namespace PackageExplorer
                 }
                 catch (System.Runtime.InteropServices.ExternalException)
                 {
-                    MessageBox.Show(this, "Failed to copy validation summary to clipboard.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(this, StringResources.Copy_Error, StringResources.Error, MessageBoxButton.OK, MessageBoxImage.Error);
                 }
             }
         }

--- a/PackageExplorer/ValidationResultWindow.xaml.cs
+++ b/PackageExplorer/ValidationResultWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.Windows;
 using NuGetPe;
+using Clipboard = System.Windows.Forms.Clipboard;
 
 using PackageExplorerViewModel;
 
@@ -27,7 +28,7 @@ namespace PackageExplorer
         {
             if (DataContext is ValidationResultViewModel viewModel)
             {
-                Clipboard.SetText(viewModel.CopyValidationMessage);
+                Clipboard.SetText(viewModel.ValidationSummary);
             }
         }
 

--- a/PackageExplorer/ValidationResultWindow.xaml.cs
+++ b/PackageExplorer/ValidationResultWindow.xaml.cs
@@ -1,6 +1,8 @@
 ﻿using System.Windows;
 using NuGetPe;
 
+using PackageExplorerViewModel;
+
 namespace PackageExplorer
 {
     /// <summary>
@@ -19,6 +21,14 @@ namespace PackageExplorer
         private void Button_Click(object sender, RoutedEventArgs e)
         {
             DialogResult = true;
+        }
+
+        private void CopyButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is ValidationResultViewModel viewModel)
+            {
+                Clipboard.SetText(viewModel.CopyValidationMessage);
+            }
         }
 
     }

--- a/PackageExplorer/ValidationResultWindow.xaml.cs
+++ b/PackageExplorer/ValidationResultWindow.xaml.cs
@@ -28,7 +28,14 @@ namespace PackageExplorer
         {
             if (DataContext is ValidationResultViewModel viewModel)
             {
-                Clipboard.SetText(viewModel.ValidationSummary);
+                try
+                {
+                    Clipboard.SetText(viewModel.ValidationSummary);
+                }
+                catch (System.Runtime.InteropServices.ExternalException)
+                {
+                    MessageBox.Show(this, "Failed to copy validation summary to clipboard.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                }
             }
         }
 

--- a/PackageViewModel/Resources.resx
+++ b/PackageViewModel/Resources.resx
@@ -252,11 +252,17 @@
   <data name="Validation_Disallowed" xml:space="preserve">
     <value>Disallowed</value>
   </data>
+  <data name="Validation_False" xml:space="preserve">
+    <value>False</value>
+  </data>
   <data name="Validation_Result" xml:space="preserve">
     <value>Validation Result</value>
   </data>
   <data name="Validation_Suspect" xml:space="preserve">
     <value>Suspect</value>
+  </data>
+  <data name="Validation_True" xml:space="preserve">
+    <value>True</value>
   </data>
   <data name="Validation_Unknown" xml:space="preserve">
     <value>Unknown</value>

--- a/PackageViewModel/Resources.resx
+++ b/PackageViewModel/Resources.resx
@@ -234,4 +234,22 @@
   <data name="UnsupportedFormatMessage" xml:space="preserve">
     <value>*** The format of this file is not supported. ***</value>
   </data>
+  <data name="ValidationResult_Errors" xml:space="preserve">
+    <value>Errors:</value>
+  </data>
+  <data name="ValidationResult_Info" xml:space="preserve">
+    <value>Information:</value>
+  </data>
+  <data name="ValidationResult_Signed" xml:space="preserve">
+    <value>Signed</value>
+  </data>
+  <data name="ValidationResult_Trust_Level" xml:space="preserve">
+    <value>Trust Level</value>
+  </data>
+  <data name="ValidationResult_Warnings" xml:space="preserve">
+    <value>Warnings:</value>
+  </data>
+  <data name="Validation_Result" xml:space="preserve">
+    <value>Validation Result</value>
+  </data>
 </root>

--- a/PackageViewModel/Resources.resx
+++ b/PackageViewModel/Resources.resx
@@ -249,7 +249,19 @@
   <data name="ValidationResult_Warnings" xml:space="preserve">
     <value>Warnings:</value>
   </data>
+  <data name="Validation_Disallowed" xml:space="preserve">
+    <value>Disallowed</value>
+  </data>
   <data name="Validation_Result" xml:space="preserve">
     <value>Validation Result</value>
+  </data>
+  <data name="Validation_Suspect" xml:space="preserve">
+    <value>Suspect</value>
+  </data>
+  <data name="Validation_Unknown" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
+  <data name="Validation_Valid" xml:space="preserve">
+    <value>Valid</value>
   </data>
 </root>

--- a/PackageViewModel/ValidationResultViewModel.cs
+++ b/PackageViewModel/ValidationResultViewModel.cs
@@ -1,11 +1,7 @@
 ﻿using System.Globalization;
-using System.Resources;
 using System.Text;
-
 using NuGet.Common;
 using NuGet.Packaging.Signing;
-
-using CI = System.Globalization.CultureInfo;
 
 
 namespace PackageExplorerViewModel
@@ -13,8 +9,7 @@ namespace PackageExplorerViewModel
     public sealed class ValidationResultViewModel
     {
         private readonly VerifySignaturesResult _verifySignaturesResult;
-        private static ResourceManager resManager => Resources.ResourceManager;
-        private static CultureInfo cultureInfo => CultureInfo.CurrentCulture;
+        private static CultureInfo cultureInfo => CultureInfo.CurrentUICulture;
 
         public ValidationResultViewModel(VerifySignaturesResult verifySignaturesResult)
         {
@@ -34,14 +29,15 @@ namespace PackageExplorerViewModel
         {
             get
             {
-                var messageBuilder = new StringBuilder(); 
-                messageBuilder.AppendLine(CI.CurrentCulture, $"Validation Result: {Valid}");
-                messageBuilder.AppendLine(CI.CurrentCulture, $"Signed: {Signed}");
-                messageBuilder.AppendLine(CI.CurrentCulture, $"Trust Level: {Trust}");
+                var messageBuilder = new StringBuilder();
+
+                messageBuilder.AppendLine(cultureInfo, $"{Resources.Validation_Result}: {Valid}");
+                messageBuilder.AppendLine(cultureInfo, $"{Resources.ValidationResult_Signed}: {Signed}");
+                messageBuilder.AppendLine(cultureInfo, $"{Resources.ValidationResult_Trust_Level}: {Trust}");
 
                 if (ErrorIssues.Count > 0)
                 {
-                    messageBuilder.AppendLine(resManager.GetString("ValidationResult_Errors", cultureInfo));
+                    messageBuilder.AppendLine(cultureInfo, $"{Resources.ValidationResult_Errors}");
                     foreach (var issue in ErrorIssues)
                     {
                         messageBuilder.AppendLine(issue.Message);
@@ -50,7 +46,7 @@ namespace PackageExplorerViewModel
 
                 if (WarningIssues.Count > 0)
                 {
-                    messageBuilder.AppendLine(resManager.GetString("ValidationResult_Warnings", cultureInfo));
+                    messageBuilder.AppendLine(cultureInfo, $"{Resources.ValidationResult_Warnings}");
                     foreach (var issue in WarningIssues)
                     {
                         messageBuilder.AppendLine(issue.Message);
@@ -59,7 +55,7 @@ namespace PackageExplorerViewModel
 
                 if (InformationIssues.Count > 0)
                 {
-                    messageBuilder.AppendLine(resManager.GetString("ValidationResult_Info", cultureInfo));
+                    messageBuilder.AppendLine(cultureInfo, $"{Resources.ValidationResult_Info}");
                     foreach (var issue in InformationIssues)
                     {
                         messageBuilder.AppendLine(issue.Message);

--- a/PackageViewModel/ValidationResultViewModel.cs
+++ b/PackageViewModel/ValidationResultViewModel.cs
@@ -31,8 +31,8 @@ namespace PackageExplorerViewModel
             {
                 var messageBuilder = new StringBuilder();
 
-                messageBuilder.AppendLine(cultureInfo, $"{Resources.Validation_Result}: {Valid}");
-                messageBuilder.AppendLine(cultureInfo, $"{Resources.ValidationResult_Signed}: {Signed}");
+                messageBuilder.AppendLine(cultureInfo, $"{Resources.Validation_Result}: {(Valid ? Resources.Validation_True : Resources.Validation_False)}");
+                messageBuilder.AppendLine(cultureInfo, $"{Resources.ValidationResult_Signed}: {(Signed ? Resources.Validation_True : Resources.Validation_False)}");
                 messageBuilder.AppendLine(cultureInfo, $"{Resources.ValidationResult_Trust_Level}: {GetLocalizedTrustText(Trust)}");
 
                 if (ErrorIssues.Count > 0)

--- a/PackageViewModel/ValidationResultViewModel.cs
+++ b/PackageViewModel/ValidationResultViewModel.cs
@@ -53,13 +53,13 @@ namespace PackageExplorerViewModel
                     messageBuilder.AppendLine(resManager.GetString("ValidationResult_Warnings", cultureInfo));
                     foreach (var issue in WarningIssues)
                     {
-                        messageBuilder.AppendLine(resManager.GetString("ValidationResult_Info", cultureInfo));
+                        messageBuilder.AppendLine(issue.Message);
                     }
                 }
 
                 if (InformationIssues.Count > 0)
                 {
-                    messageBuilder.AppendLine("Information:");
+                    messageBuilder.AppendLine(resManager.GetString("ValidationResult_Info", cultureInfo));
                     foreach (var issue in InformationIssues)
                     {
                         messageBuilder.AppendLine(issue.Message);

--- a/PackageViewModel/ValidationResultViewModel.cs
+++ b/PackageViewModel/ValidationResultViewModel.cs
@@ -33,7 +33,7 @@ namespace PackageExplorerViewModel
 
                 messageBuilder.AppendLine(cultureInfo, $"{Resources.Validation_Result}: {Valid}");
                 messageBuilder.AppendLine(cultureInfo, $"{Resources.ValidationResult_Signed}: {Signed}");
-                messageBuilder.AppendLine(cultureInfo, $"{Resources.ValidationResult_Trust_Level}: {Trust}");
+                messageBuilder.AppendLine(cultureInfo, $"{Resources.ValidationResult_Trust_Level}: {GetLocalizedTrustText(Trust)}");
 
                 if (ErrorIssues.Count > 0)
                 {
@@ -66,6 +66,16 @@ namespace PackageExplorerViewModel
             }
             
         }
+
+        private static string GetLocalizedTrustText(SignatureVerificationStatus trust) =>
+            trust switch
+            {
+                SignatureVerificationStatus.Valid => Resources.Validation_Valid,
+                SignatureVerificationStatus.Disallowed => Resources.Validation_Disallowed,
+                SignatureVerificationStatus.Unknown => Resources.Validation_Unknown,
+                SignatureVerificationStatus.Suspect => Resources.Validation_Suspect,
+                _ => Resources.Validation_Unknown
+            };
 
 
         public bool Valid => _verifySignaturesResult.IsValid;

--- a/PackageViewModel/ValidationResultViewModel.cs
+++ b/PackageViewModel/ValidationResultViewModel.cs
@@ -1,7 +1,11 @@
-﻿using System.Text;
-using CI = System.Globalization.CultureInfo;
+﻿using System.Globalization;
+using System.Resources;
+using System.Text;
+
 using NuGet.Common;
 using NuGet.Packaging.Signing;
+
+using CI = System.Globalization.CultureInfo;
 
 
 namespace PackageExplorerViewModel
@@ -9,6 +13,8 @@ namespace PackageExplorerViewModel
     public sealed class ValidationResultViewModel
     {
         private readonly VerifySignaturesResult _verifySignaturesResult;
+        private static ResourceManager resManager => Resources.ResourceManager;
+        private static CultureInfo cultureInfo => CultureInfo.CurrentCulture;
 
         public ValidationResultViewModel(VerifySignaturesResult verifySignaturesResult)
         {
@@ -35,7 +41,7 @@ namespace PackageExplorerViewModel
 
                 if (ErrorIssues.Count > 0)
                 {
-                    messageBuilder.AppendLine("Errors:");
+                    messageBuilder.AppendLine(resManager.GetString("ValidationResult_Errors", cultureInfo));
                     foreach (var issue in ErrorIssues)
                     {
                         messageBuilder.AppendLine(issue.Message);
@@ -44,10 +50,10 @@ namespace PackageExplorerViewModel
 
                 if (WarningIssues.Count > 0)
                 {
-                    messageBuilder.AppendLine("Warnings:");
+                    messageBuilder.AppendLine(resManager.GetString("ValidationResult_Warnings", cultureInfo));
                     foreach (var issue in WarningIssues)
                     {
-                        messageBuilder.AppendLine(issue.Message);
+                        messageBuilder.AppendLine(resManager.GetString("ValidationResult_Info", cultureInfo));
                     }
                 }
 

--- a/PackageViewModel/ValidationResultViewModel.cs
+++ b/PackageViewModel/ValidationResultViewModel.cs
@@ -24,7 +24,7 @@ namespace PackageExplorerViewModel
                                                       .ToList();
         }
 
-        public string CopyValidationMessage
+        public string ValidationSummary
         {
             get
             {
@@ -33,30 +33,30 @@ namespace PackageExplorerViewModel
                 messageBuilder.AppendLine(CI.CurrentCulture, $"Signed: {Signed}");
                 messageBuilder.AppendLine(CI.CurrentCulture, $"Trust Level: {Trust}");
 
-                if (ErrorIssues?.Count > 0)
+                if (ErrorIssues.Count > 0)
                 {
-                    messageBuilder.AppendLine(CI.CurrentCulture, $"Errors:");
+                    messageBuilder.AppendLine("Errors:");
                     foreach (var issue in ErrorIssues)
                     {
-                        messageBuilder.AppendLine(CI.CurrentCulture, $"{issue.Message}");
+                        messageBuilder.AppendLine(issue.Message);
                     }
                 }
 
-                if (WarningIssues?.Count > 0)
+                if (WarningIssues.Count > 0)
                 {
-                    messageBuilder.AppendLine(CI.CurrentCulture, $"Warnings:");
+                    messageBuilder.AppendLine("Warnings:");
                     foreach (var issue in WarningIssues)
                     {
-                        messageBuilder.AppendLine(CI.CurrentCulture, $"{issue.Message}");
+                        messageBuilder.AppendLine(issue.Message);
                     }
                 }
 
-                if(InformationIssues?.Count > 0)
+                if (InformationIssues.Count > 0)
                 {
-                    messageBuilder.AppendLine(CI.CurrentCulture, $"Information:");
+                    messageBuilder.AppendLine("Information:");
                     foreach (var issue in InformationIssues)
                     {
-                        messageBuilder.AppendLine(CI.CurrentCulture, $"{issue.Message}");
+                        messageBuilder.AppendLine(issue.Message);
                     }
                 }
 

--- a/PackageViewModel/ValidationResultViewModel.cs
+++ b/PackageViewModel/ValidationResultViewModel.cs
@@ -1,4 +1,6 @@
-﻿using NuGet.Common;
+﻿using System.Text;
+using CI = System.Globalization.CultureInfo;
+using NuGet.Common;
 using NuGet.Packaging.Signing;
 
 
@@ -20,6 +22,47 @@ namespace PackageExplorerViewModel
                                                       .SelectMany(static prv => prv.Issues)
                                                       .Where(static sl => sl.Level == LogLevel.Information)
                                                       .ToList();
+        }
+
+        public string CopyValidationMessage
+        {
+            get
+            {
+                var messageBuilder = new StringBuilder(); 
+                messageBuilder.AppendLine(CI.CurrentCulture, $"Validation Result: {Valid}");
+                messageBuilder.AppendLine(CI.CurrentCulture, $"Signed: {Signed}");
+                messageBuilder.AppendLine(CI.CurrentCulture, $"Trust Level: {Trust}");
+
+                if (ErrorIssues?.Count > 0)
+                {
+                    messageBuilder.AppendLine(CI.CurrentCulture, $"Errors:");
+                    foreach (var issue in ErrorIssues)
+                    {
+                        messageBuilder.AppendLine(CI.CurrentCulture, $"{issue.Message}");
+                    }
+                }
+
+                if (WarningIssues?.Count > 0)
+                {
+                    messageBuilder.AppendLine(CI.CurrentCulture, $"Warnings:");
+                    foreach (var issue in WarningIssues)
+                    {
+                        messageBuilder.AppendLine(CI.CurrentCulture, $"{issue.Message}");
+                    }
+                }
+
+                if(InformationIssues?.Count > 0)
+                {
+                    messageBuilder.AppendLine(CI.CurrentCulture, $"Information:");
+                    foreach (var issue in InformationIssues)
+                    {
+                        messageBuilder.AppendLine(CI.CurrentCulture, $"{issue.Message}");
+                    }
+                }
+
+                return messageBuilder.ToString();
+            }
+            
         }
 
 


### PR DESCRIPTION
This pull request adds a new `Copy` button to the package's validation result window. On button click, it copies the validation results to clipboard.

**UI Changes:**
- Added a new `Copy` button to `ValidationResultWindow.xaml`  and a button click handler in `ValidationResultWindow.xaml.cs`
- New property in `ValidationResultViewModel.cs` that reads the validation result text.

**Reference:** The PR addresses [this issue request](https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/issues/1735)

**Copied Result Example:**

> Validation Result: True
Signed: True
Trust Level: Valid
Information:
Signature Hash Algorithm: SHA256
Verifying the author primary signature with certificate: 
  SHA1 hash: 1A9FF7E5BDC4E3E5E2F14E4B2DA6029C5AE58DBF
  Issued by: CN=.NET Foundation Projects Code Signing CA2, O=.NET Foundation, C=US
  Timestamp: 16-09-2025 01:34:26 PM
  ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Copy" button to validation result dialogs to copy the full validation summary to the clipboard.
  * Summary now always shows validation result, signature status, and trust level, and includes Errors/Warnings/Information sections when present.

* **Bug Fixes / UX**
  * Clipboard failures are handled and show a friendly error message if copying fails.

* **Localization**
  * Added localized labels for the copy action and validation section headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->