### PR TITLE
fix: harden wasm package downloads and ci packaging builds

### DIFF
--- a/PackageExplorer/MefServices/PackageDownloader.cs
+++ b/PackageExplorer/MefServices/PackageDownloader.cs
@@ -253,14 +253,14 @@ namespace PackageExplorer
                 var path = $"./tmp/{Guid.NewGuid()}.nupkg";
                 Directory.CreateDirectory(Path.GetDirectoryName(path!)!);
 
-                await using var packageStream = await NugetEndpoint.DownloadPackage(
+                await using var file = File.OpenWrite(path);
+                await NugetEndpoint.DownloadPackage(
                     cancellationToken,
                     packageIdentity.Id,
                     packageIdentity.Version.ToNormalizedString(),
+                    file,
                     progress: NullProgress.Instance).ConfigureAwait(false);
-
-                await using var file = File.OpenWrite(path);
-                await packageStream.CopyToAsync(file, cancellationToken).ConfigureAwait(false);
+                await file.FlushAsync(cancellationToken).ConfigureAwait(false);
 
                 return path;
             }

--- a/PackageExplorer/MefServices/PackageDownloader.cs
+++ b/PackageExplorer/MefServices/PackageDownloader.cs
@@ -255,11 +255,11 @@ namespace PackageExplorer
 
                 await using var file = File.OpenWrite(path);
                 await NugetEndpoint.DownloadPackage(
-                    cancellationToken,
                     packageIdentity.Id,
                     packageIdentity.Version.ToNormalizedString(),
                     file,
-                    progress: NullProgress.Instance).ConfigureAwait(false);
+                    progress: NullProgress.Instance,
+                    cancellationToken).ConfigureAwait(false);
                 await file.FlushAsync(cancellationToken).ConfigureAwait(false);
 
                 return path;

--- a/Uno/NugetPackageExplorer.Legacy/Client/INugetEndpoint.cs
+++ b/Uno/NugetPackageExplorer.Legacy/Client/INugetEndpoint.cs
@@ -11,6 +11,6 @@ namespace NupkgExplorer.Client
 
         Task<Stream> DownloadPackage(string packageId, string version);
 
-        Task DownloadPackage(CancellationToken ct, string packageId, string version, Stream destination, IProgress<(long ReceivedBytes, long? TotalBytes)> progress);
+        Task DownloadPackage(string packageId, string version, Stream destination, IProgress<(long ReceivedBytes, long? TotalBytes)> progress, CancellationToken ct);
     }
 }

--- a/Uno/NugetPackageExplorer.Legacy/Client/INugetEndpoint.cs
+++ b/Uno/NugetPackageExplorer.Legacy/Client/INugetEndpoint.cs
@@ -11,6 +11,6 @@ namespace NupkgExplorer.Client
 
         Task<Stream> DownloadPackage(string packageId, string version);
 
-        Task<Stream> DownloadPackage(CancellationToken ct, string packageId, string version, IProgress<(long ReceivedBytes, long? TotalBytes)> progress);
+        Task DownloadPackage(CancellationToken ct, string packageId, string version, Stream destination, IProgress<(long ReceivedBytes, long? TotalBytes)> progress);
     }
 }

--- a/Uno/NugetPackageExplorer.Legacy/Client/Impl/NugetEndpoint.cs
+++ b/Uno/NugetPackageExplorer.Legacy/Client/Impl/NugetEndpoint.cs
@@ -56,7 +56,7 @@ namespace NupkgExplorer.Client.Impl
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "It's what the URL needs to be")]
-        public async Task DownloadPackage(CancellationToken ct, string packageId, string version, Stream destination, IProgress<(long ReceivedBytes, long? TotalBytes)> progress)
+        public async Task DownloadPackage(string packageId, string version, Stream destination, IProgress<(long ReceivedBytes, long? TotalBytes)> progress, CancellationToken ct)
         {
             ArgumentNullException.ThrowIfNullOrWhiteSpace(packageId);
             ArgumentNullException.ThrowIfNullOrWhiteSpace(version);

--- a/Uno/NugetPackageExplorer.Legacy/Client/Impl/NugetEndpoint.cs
+++ b/Uno/NugetPackageExplorer.Legacy/Client/Impl/NugetEndpoint.cs
@@ -56,40 +56,29 @@ namespace NupkgExplorer.Client.Impl
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "It's what the URL needs to be")]
-        public async Task<Stream> DownloadPackage(CancellationToken ct, string packageId, string version, IProgress<(long ReceivedBytes, long? TotalBytes)> progress)
+        public async Task DownloadPackage(CancellationToken ct, string packageId, string version, Stream destination, IProgress<(long ReceivedBytes, long? TotalBytes)> progress)
         {
             ArgumentNullException.ThrowIfNullOrWhiteSpace(packageId);
             ArgumentNullException.ThrowIfNullOrWhiteSpace(version);
+            ArgumentNullException.ThrowIfNull(destination);
             ArgumentNullException.ThrowIfNull(progress);
 
             packageId = packageId.ToLowerInvariant();
             version = version.ToLowerInvariant();
 
             // https://docs.microsoft.com/en-us/nuget/api/package-base-address-resource
-            var response = await Query(query => query
+            using var response = await Query(query => query
                 .Get()
                 .FromUrl($"https://api.nuget.org/v3-flatcontainer/{packageId}/{version}/{packageId}.{version}.nupkg")
-            );
+            ).ConfigureAwait(false);
 
             var total = response.Content.Headers.ContentLength;
-            long read = 0, received = 0;
-            var buffer = new Memory<byte>(new byte[2 << 12]);
-            progress.Report((received, total));
-
-            var stream = new MemoryStream((int)(total ?? 0));
-            using (var content = await response.Content.ReadAsStreamAsync())
+            progress.Report((0, total));
+            await response.Content.CopyToAsync(destination, ct).ConfigureAwait(false);
+            if (total.HasValue)
             {
-                while ((read = await content.ReadAsync(buffer)) > 0)
-                {
-                    await stream.WriteAsync(buffer[..(int)read]);
-                    progress.Report((received += read, total));
-                    ct.ThrowIfCancellationRequested();
-                }
-                progress.Report((received += read, total));
+                progress.Report((total.Value, total));
             }
-
-            stream.Position = 0;
-            return stream;
         }
     }
 }

--- a/Uno/NugetPackageExplorer.Legacy/Client/Impl/NugetEndpoint.cs
+++ b/Uno/NugetPackageExplorer.Legacy/Client/Impl/NugetEndpoint.cs
@@ -66,7 +66,7 @@ namespace NupkgExplorer.Client.Impl
             version = version.ToLowerInvariant();
 
             // https://docs.microsoft.com/en-us/nuget/api/package-base-address-resource
-            var response = await Query(HttpCompletionOption.ResponseHeadersRead, query => query
+            var response = await Query(query => query
                 .Get()
                 .FromUrl($"https://api.nuget.org/v3-flatcontainer/{packageId}/{version}/{packageId}.{version}.nupkg")
             );

--- a/Uno/NugetPackageExplorer.Legacy/Client/Impl/NugetEndpoint.cs
+++ b/Uno/NugetPackageExplorer.Legacy/Client/Impl/NugetEndpoint.cs
@@ -67,18 +67,29 @@ namespace NupkgExplorer.Client.Impl
             version = version.ToLowerInvariant();
 
             // https://docs.microsoft.com/en-us/nuget/api/package-base-address-resource
-            using var response = await Query(query => query
-                .Get()
-                .FromUrl($"https://api.nuget.org/v3-flatcontainer/{packageId}/{version}/{packageId}.{version}.nupkg")
-            ).ConfigureAwait(false);
+            using var request = new HttpRequestMessage(
+                HttpMethod.Get,
+                $"https://api.nuget.org/v3-flatcontainer/{packageId}/{version}/{packageId}.{version}.nupkg");
+            using var response = await Client.SendAsync(request, HttpCompletionOption.ResponseContentRead, ct).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
 
             var total = response.Content.Headers.ContentLength;
-            progress.Report((0, total));
-            await response.Content.CopyToAsync(destination, ct).ConfigureAwait(false);
-            if (total.HasValue)
+            long received = 0;
+            var buffer = new Memory<byte>(new byte[2 << 12]);
+            progress.Report((received, total));
+
+            await using (var content = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false))
             {
-                progress.Report((total.Value, total));
+                int read;
+                while ((read = await content.ReadAsync(buffer, ct).ConfigureAwait(false)) > 0)
+                {
+                    await destination.WriteAsync(buffer[..read], ct).ConfigureAwait(false);
+                    received += read;
+                    progress.Report((received, total));
+                }
             }
+
+            progress.Report((received, total));
         }
     }
 }

--- a/Uno/NugetPackageExplorer.Legacy/Framework/Query/ApiEndpointBase.cs
+++ b/Uno/NugetPackageExplorer.Legacy/Framework/Query/ApiEndpointBase.cs
@@ -8,6 +8,7 @@ namespace NupkgExplorer.Framework.Query
     public abstract class ApiEndpointBase
     {
         private readonly HttpClient _client;
+        protected HttpClient Client => _client;
 
         protected ApiEndpointBase()
         {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,6 +91,8 @@ stages:
       displayName: Build Package
       inputs:
         solution: PackageExplorer.Package/PackageExplorer.Package.wapproj
+        msbuildLocationMethod: version
+        msbuildVersion: '18.0'
         msbuildArguments: /restore /p:AppxPackageDir="$(Build.SourcesDirectory)\artifacts\$(ReleaseChannel)\\" /bl:$(Build.SourcesDirectory)\artifacts\logs\$(ReleaseChannel).binlog
         configuration: $(BuildConfiguration)
         maximumCpuCount: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,7 +93,7 @@ stages:
         if (-not $vsInstall) {
           throw 'Could not locate a Visual Studio installation with MSBuild via vswhere.'
         }
-        $wapProjPath = Join-Path $vsInstall 'MSBuild\Microsoft\DesktopBridge\'
+        $wapProjPath = Join-Path $vsInstall 'MSBuild\Microsoft\DesktopBridge'
 
         dotnet msbuild `
           PackageExplorer.Package/PackageExplorer.Package.wapproj `

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ stages:
     - task: UseDotNet@2
       displayName: 'Use .NET 10 SDK'
       inputs:
-        useGlobalJson: true
+        version: 10.x
 
     - script: dotnet workload install wasm-tools wasm-tools-net9
       displayName: Install workloads
@@ -87,13 +87,26 @@ stages:
         AppInsightsKey: $(AppInsightsKey)
       condition: and(succeeded(), not(eq(variables['build.reason'], 'PullRequest')), not(eq(variables['AppInsightsKey'], '')))
 
-    - task: MSBuild@1
-      displayName: Build Package
-      inputs:
-        solution: PackageExplorer.Package/PackageExplorer.Package.wapproj
-        msbuildArguments: /restore /p:AppxPackageDir="$(Build.SourcesDirectory)\artifacts\$(ReleaseChannel)\\" /bl:$(Build.SourcesDirectory)\artifacts\logs\$(ReleaseChannel).binlog
-        configuration: $(BuildConfiguration)
-        maximumCpuCount: true
+    - powershell: |
+        $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+        $msbuild = & $vswhere `
+          -prerelease `
+          -latest `
+          -products * `
+          -requires Microsoft.Component.MSBuild `
+          -find MSBuild\**\Bin\amd64\MSBuild.exe | Select-Object -First 1
+
+        if (-not $msbuild) {
+          throw 'Could not locate the latest prerelease x64 MSBuild with vswhere.'
+        }
+
+        & $msbuild `
+          PackageExplorer.Package/PackageExplorer.Package.wapproj `
+          /restore `
+          /m `
+          /p:Configuration=$(BuildConfiguration) `
+          /p:AppxPackageDir="$(Build.SourcesDirectory)\artifacts\$(ReleaseChannel)\\" `
+          /bl:$(Build.SourcesDirectory)\artifacts\logs\$(ReleaseChannel).binlog
       condition: and(succeeded(), or(eq(variables['ReleaseChannel'], 'Nightly'), eq(variables['ReleaseChannel'], 'Store')))
 
     - task: DotNetCoreCLI@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ stages:
     - task: UseDotNet@2
       displayName: 'Use .NET 10 SDK'
       inputs:
-        version: 10.x
+        useGlobalJson: true
 
     - script: dotnet workload install wasm-tools wasm-tools-net9
       displayName: Install workloads
@@ -87,23 +87,13 @@ stages:
         AppInsightsKey: $(AppInsightsKey)
       condition: and(succeeded(), not(eq(variables['build.reason'], 'PullRequest')), not(eq(variables['AppInsightsKey'], '')))
 
-    - powershell: |
-        $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
-        $vsInstall = & $vswhere -latest -requires Microsoft.Component.MSBuild -property installationPath | Select-Object -First 1
-        if (-not $vsInstall) {
-          throw 'Could not locate a Visual Studio installation with MSBuild via vswhere.'
-        }
-        $wapProjPath = Join-Path $vsInstall 'MSBuild\Microsoft\DesktopBridge'
-
-        dotnet msbuild `
-          PackageExplorer.Package/PackageExplorer.Package.wapproj `
-          /restore `
-          /m `
-          /p:Configuration=$(BuildConfiguration) `
-          /p:WapProjPath="$wapProjPath" `
-          /p:AppxPackageDir="$(Build.SourcesDirectory)\artifacts\$(ReleaseChannel)\\" `
-          /bl:$(Build.SourcesDirectory)\artifacts\logs\$(ReleaseChannel).binlog
+    - task: MSBuild@1
       displayName: Build Package
+      inputs:
+        solution: PackageExplorer.Package/PackageExplorer.Package.wapproj
+        msbuildArguments: /restore /p:AppxPackageDir="$(Build.SourcesDirectory)\artifacts\$(ReleaseChannel)\\" /bl:$(Build.SourcesDirectory)\artifacts\logs\$(ReleaseChannel).binlog
+        configuration: $(BuildConfiguration)
+        maximumCpuCount: true
       condition: and(succeeded(), or(eq(variables['ReleaseChannel'], 'Nightly'), eq(variables['ReleaseChannel'], 'Store')))
 
     - task: DotNetCoreCLI@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ stages:
   jobs:
   - job: Build
     pool:
-      vmImage: windows-latest
+      vmImage: windows-2025-vs2026
     strategy:
       matrix:
         Channel_Zip:
@@ -87,26 +87,13 @@ stages:
         AppInsightsKey: $(AppInsightsKey)
       condition: and(succeeded(), not(eq(variables['build.reason'], 'PullRequest')), not(eq(variables['AppInsightsKey'], '')))
 
-    - powershell: |
-        $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
-        $msbuild = & $vswhere `
-          -prerelease `
-          -latest `
-          -products * `
-          -requires Microsoft.Component.MSBuild `
-          -find MSBuild\**\Bin\amd64\MSBuild.exe | Select-Object -First 1
-
-        if (-not $msbuild) {
-          throw 'Could not locate the latest prerelease x64 MSBuild with vswhere.'
-        }
-
-        & $msbuild `
-          PackageExplorer.Package/PackageExplorer.Package.wapproj `
-          /restore `
-          /m `
-          /p:Configuration=$(BuildConfiguration) `
-          /p:AppxPackageDir="$(Build.SourcesDirectory)\artifacts\$(ReleaseChannel)\\" `
-          /bl:$(Build.SourcesDirectory)\artifacts\logs\$(ReleaseChannel).binlog
+    - task: MSBuild@1
+      displayName: Build Package
+      inputs:
+        solution: PackageExplorer.Package/PackageExplorer.Package.wapproj
+        msbuildArguments: /restore /p:AppxPackageDir="$(Build.SourcesDirectory)\artifacts\$(ReleaseChannel)\\" /bl:$(Build.SourcesDirectory)\artifacts\logs\$(ReleaseChannel).binlog
+        configuration: $(BuildConfiguration)
+        maximumCpuCount: true
       condition: and(succeeded(), or(eq(variables['ReleaseChannel'], 'Nightly'), eq(variables['ReleaseChannel'], 'Store')))
 
     - task: DotNetCoreCLI@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,16 +89,18 @@ stages:
 
     - powershell: |
         $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
-        $msbuild = & $vswhere -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\amd64\MSBuild.exe | Select-Object -First 1
-        if (-not $msbuild) {
-          throw 'Could not locate the latest x64 MSBuild with vswhere.'
+        $vsInstall = & $vswhere -latest -requires Microsoft.Component.MSBuild -property installationPath | Select-Object -First 1
+        if (-not $vsInstall) {
+          throw 'Could not locate a Visual Studio installation with MSBuild via vswhere.'
         }
+        $wapProjPath = Join-Path $vsInstall 'MSBuild\Microsoft\DesktopBridge\'
 
-        & $msbuild `
+        dotnet msbuild `
           PackageExplorer.Package/PackageExplorer.Package.wapproj `
           /restore `
           /m `
           /p:Configuration=$(BuildConfiguration) `
+          /p:WapProjPath="$wapProjPath" `
           /p:AppxPackageDir="$(Build.SourcesDirectory)\artifacts\$(ReleaseChannel)\\" `
           /bl:$(Build.SourcesDirectory)\artifacts\logs\$(ReleaseChannel).binlog
       displayName: Build Package

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,6 +92,7 @@ stages:
       inputs:
         solution: PackageExplorer.Package/PackageExplorer.Package.wapproj
         msbuildLocationMethod: version
+        msbuildArchitecture: x64
         msbuildVersion: '18.0'
         msbuildArguments: /restore /p:AppxPackageDir="$(Build.SourcesDirectory)\artifacts\$(ReleaseChannel)\\" /bl:$(Build.SourcesDirectory)\artifacts\logs\$(ReleaseChannel).binlog
         configuration: $(BuildConfiguration)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,16 +87,21 @@ stages:
         AppInsightsKey: $(AppInsightsKey)
       condition: and(succeeded(), not(eq(variables['build.reason'], 'PullRequest')), not(eq(variables['AppInsightsKey'], '')))
 
-    - task: MSBuild@1
+    - powershell: |
+        $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+        $msbuild = & $vswhere -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\amd64\MSBuild.exe | Select-Object -First 1
+        if (-not $msbuild) {
+          throw 'Could not locate the latest x64 MSBuild with vswhere.'
+        }
+
+        & $msbuild `
+          PackageExplorer.Package/PackageExplorer.Package.wapproj `
+          /restore `
+          /m `
+          /p:Configuration=$(BuildConfiguration) `
+          /p:AppxPackageDir="$(Build.SourcesDirectory)\artifacts\$(ReleaseChannel)\\" `
+          /bl:$(Build.SourcesDirectory)\artifacts\logs\$(ReleaseChannel).binlog
       displayName: Build Package
-      inputs:
-        solution: PackageExplorer.Package/PackageExplorer.Package.wapproj
-        msbuildLocationMethod: version
-        msbuildArchitecture: x64
-        msbuildVersion: '18.0'
-        msbuildArguments: /restore /p:AppxPackageDir="$(Build.SourcesDirectory)\artifacts\$(ReleaseChannel)\\" /bl:$(Build.SourcesDirectory)\artifacts\logs\$(ReleaseChannel).binlog
-        configuration: $(BuildConfiguration)
-        maximumCpuCount: true
       condition: and(succeeded(), or(eq(variables['ReleaseChannel'], 'Nightly'), eq(variables['ReleaseChannel'], 'Store')))
 
     - task: DotNetCoreCLI@2

--- a/scripts/start-swa-routing.mjs
+++ b/scripts/start-swa-routing.mjs
@@ -14,7 +14,6 @@ const apiPort = process.env.NPE_API_TEST_PORT ?? "7071";
 const configuration = process.env.NPE_WASM_TEST_CONFIGURATION ?? "Release";
 const runtimeMode = process.env.NPE_WASM_TEST_RUNTIME_MODE;
 const disableJiterpreter = process.env.NPE_WASM_TEST_DISABLE_JITERPRETER === "1";
-const unoOverrideVersion = process.env.NPE_WASM_TEST_UNO_OVERRIDE_VERSION;
 const childEnvironment = {
   ...process.env,
   CI: process.env.CI ?? "1",
@@ -35,10 +34,6 @@ if (runtimeMode) {
 
 if (disableJiterpreter) {
   publishArgs.push("-p:WasmShellEnableJiterpreter=false");
-}
-
-if (unoOverrideVersion) {
-  publishArgs.push(`-p:UnoNugetOverrideVersion=${unoOverrideVersion}`);
 }
 
 const publishFolder = `artifacts/publish/NuGetPackageExplorer.WinUI/${configuration.toLowerCase()}_net10.0-browserwasm/wwwroot`;

--- a/scripts/start-swa-routing.mjs
+++ b/scripts/start-swa-routing.mjs
@@ -11,17 +11,41 @@ import {
 
 const port = process.env.NPE_WASM_TEST_PORT ?? "4281";
 const apiPort = process.env.NPE_API_TEST_PORT ?? "7071";
+const configuration = process.env.NPE_WASM_TEST_CONFIGURATION ?? "Release";
+const runtimeMode = process.env.NPE_WASM_TEST_RUNTIME_MODE;
+const disableJiterpreter = process.env.NPE_WASM_TEST_DISABLE_JITERPRETER === "1";
+const unoOverrideVersion = process.env.NPE_WASM_TEST_UNO_OVERRIDE_VERSION;
+const childEnvironment = {
+  ...process.env,
+  CI: process.env.CI ?? "1",
+  FUNCTIONS_CORE_TOOLS_TELEMETRY_OPTOUT: process.env.FUNCTIONS_CORE_TOOLS_TELEMETRY_OPTOUT ?? "1"
+};
 const publishArgs = [
   "publish",
   "Uno/NuGetPackageExplorer/NuGetPackageExplorer.WinUI.csproj",
   "-f",
   "net10.0-browserwasm",
   "-c",
-  "Release"
+  configuration
 ];
+
+if (runtimeMode) {
+  publishArgs.push(`-p:WasmShellMonoRuntimeExecutionMode=${runtimeMode}`);
+}
+
+if (disableJiterpreter) {
+  publishArgs.push("-p:WasmShellEnableJiterpreter=false");
+}
+
+if (unoOverrideVersion) {
+  publishArgs.push(`-p:UnoNugetOverrideVersion=${unoOverrideVersion}`);
+}
+
+const publishFolder = `artifacts/publish/NuGetPackageExplorer.WinUI/${configuration.toLowerCase()}_net10.0-browserwasm/wwwroot`;
 
 const publish = spawnSync("dotnet", publishArgs, {
   cwd: process.cwd(),
+  env: childEnvironment,
   stdio: "inherit",
   shell: process.platform === "win32"
 });
@@ -38,10 +62,13 @@ const func = spawn(
   [
     "start",
     "--port",
-    apiPort
+    apiPort,
+    "--runtime",
+    "default"
   ],
   {
     cwd: apiPath,
+    env: childEnvironment,
     stdio: "inherit",
     shell: process.platform === "win32"
   }
@@ -57,6 +84,7 @@ const waitForApi = spawnSync(
   ],
   {
     cwd: workspaceRoot,
+    env: childEnvironment,
     stdio: "inherit",
     shell: process.platform === "win32"
   }
@@ -71,7 +99,7 @@ const swa = spawn(
   getSwaExecutable(),
   [
     "start",
-    "artifacts/publish/NuGetPackageExplorer.WinUI/release_net10.0-browserwasm/wwwroot",
+    publishFolder,
     "--host",
     "127.0.0.1",
     "--port",
@@ -83,6 +111,7 @@ const swa = spawn(
   ],
   {
     cwd: workspaceRoot,
+    env: childEnvironment,
     stdio: "inherit",
     shell: process.platform === "win32"
   }

--- a/tests/wasm-routing/deep-links.spec.ts
+++ b/tests/wasm-routing/deep-links.spec.ts
@@ -19,7 +19,7 @@ const unoPackage = {
 
 const wasmPublishIndexPath = path.resolve(
   process.cwd(),
-  "artifacts/publish/NuGetPackageExplorer.WinUI/release_net10.0-browserwasm/wwwroot/index.html"
+  `artifacts/publish/NuGetPackageExplorer.WinUI/${(process.env.NPE_WASM_TEST_CONFIGURATION ?? "Release").toLowerCase()}_net10.0-browserwasm/wwwroot/index.html`
 );
 
 let publishedPackageBasePath: string | undefined;

--- a/tests/wasm-routing/deep-links.spec.ts
+++ b/tests/wasm-routing/deep-links.spec.ts
@@ -12,6 +12,11 @@ const previewPackage = {
   version: "11.0.0-preview.1.26104.118"
 };
 
+const unoPackage = {
+  id: "Uno.WinUI",
+  version: "6.5.153"
+};
+
 const wasmPublishIndexPath = path.resolve(
   process.cwd(),
   "artifacts/publish/NuGetPackageExplorer.WinUI/release_net10.0-browserwasm/wwwroot/index.html"
@@ -114,6 +119,23 @@ test("preview-version deep links keep the requested preview package open", async
   );
   await expect(page).toHaveTitle(
     new RegExp(`^${escapeRegex(previewPackage.id)} ${escapeRegex(previewPackage.version)} \\| NuGet Package Explorer$`)
+  );
+  expectNoStartupFailure(consoleMessages);
+});
+
+test("Uno.WinUI deep links keep the requested package open", async ({ page }) => {
+  const consoleMessages = captureStartupSignals(page);
+
+  await page.goto(`/packages/${unoPackage.id}/${unoPackage.version}`, {
+    waitUntil: "domcontentloaded"
+  });
+  await waitForUnoShell(page);
+
+  await expect(page).toHaveURL(
+    new RegExp(`/packages/${escapeRegex(unoPackage.id)}/${escapeRegex(unoPackage.version)}$`)
+  );
+  await expect(page).toHaveTitle(
+    new RegExp(`^${escapeRegex(unoPackage.id)} ${escapeRegex(unoPackage.version)} \\| NuGet Package Explorer$`)
   );
   expectNoStartupFailure(consoleMessages);
 });


### PR DESCRIPTION
## Issue
Large packages could fail to open in the WASM app, including `Uno.WinUI 6.5.153`.

## Root cause
The failure was in the WASM-specific remote package download path.

On WASM, the app downloads remote packages through `INugetEndpoint.DownloadPackage(...)` and then copies the result into a temp `.nupkg` file before opening it. That browser download path was the unstable part for large packages: the response handling/copy sequence could fail before the package was fully materialized on disk, which left the app unable to finish opening the package.

That same path also had two correctness gaps:
- cancellation was not propagated into the underlying HTTP request, so cancelling could only interrupt later work and not the in-flight download itself
- progress consumers did not get reliable completion semantics when the content length was missing

Separately, the Nightly and Store packaging jobs in Azure Pipelines were not running on the intended Visual Studio/MSBuild toolchain. Moving the build job to the `windows-2025-vs2026` hosted image aligns the package build with the toolchain required by the current SDK.

## Summary
- update the WASM package download path to write the downloaded package directly into the destination temp file
- propagate cancellation into the underlying WASM HTTP request and report incremental/final download progress
- make the WASM routing test harness configuration-aware and add a regression test for `Uno.WinUI 6.5.153`
- move Azure Pipelines build jobs to the `windows-2025-vs2026` hosted image

## Validation
- `dotnet build PackageExplorer/NuGetPackageExplorer.csproj -c Release /p:ReleaseChannel=Nightly`
- `npx playwright test tests/wasm-routing/deep-links.spec.ts --grep "direct versioned deep link opens the requested package|Uno\\.WinUI deep links keep the requested package open"` with `NPE_WASM_TEST_CONFIGURATION=Release` and `NPE_WASM_TEST_RUNTIME_MODE=InterpreterAndAOT`
- Azure DevOps build `124596` completed successfully, including Nightly and Store package jobs